### PR TITLE
feat: add argument groups to --help output

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -52,75 +52,82 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="FluxCast — stream your Arch Linux desktop to a Smart TV"
     )
-    parser.add_argument("--protocol", default="wfd",
-                        choices=["dlna", "cast", "wfd"],
-                        help="Connection protocol: wfd (Miracast, default), "
-                             "dlna (UPnP fallback), or cast (Chromecast built-in)")
-    parser.add_argument("--tv-ip", default=None, dest="tv_ip",
-                        help="TV IP address (only applicable for --protocol cast)")
-    parser.add_argument("--host", default=None,
-                        help="LAN IP to advertise in the stream URL (default: auto)")
-    parser.add_argument("--port", type=int, default=8080,
-                        help="HTTP server port (default: 8080)")
-    parser.add_argument("--output-res", default=None, dest="output_res",
-                        help="Scale output to WxH, e.g. 1920x1080 (default: native)")
-    parser.add_argument("--fps", type=int, default=30,
-                        help="Frames per second (default: 30)")
-    parser.add_argument("--bitrate", default="4M",
-                        help="Video bitrate (default: 4M)")
-    parser.add_argument("--discover-timeout", type=int, default=5,
-                        dest="discover_timeout",
-                        help="Discovery timeout in seconds (default: 5)")
-    parser.add_argument("--capture-backend", default="auto", dest="capture_backend",
-                        choices=["auto", "wf-recorder", "x11grab"],
-                        help="Desktop capture backend for dlna/cast: auto (default), wf-recorder, or x11grab")
-    parser.add_argument("--transport", default="progressive-ts",
-                        choices=["progressive-ts", "hls", "live-ts"],
-                        help="DLNA stream transport: progressive-ts for low latency "
-                             "(default), hls as a stable fallback, or live-ts experimental")
-    parser.add_argument("--doctor", action="store_true",
-                        help="Print passive Linux/WFD capability diagnostics and exit")
-    parser.add_argument("--doctor-json", action="store_true", dest="doctor_json",
-                        help="Print diagnostics as JSON and exit")
-    parser.add_argument("--wfd-scan", action="store_true", dest="wfd_scan",
-                        help="Run active Wi-Fi Direct discovery and exit")
-    parser.add_argument("--wfd-peer", default=None, dest="wfd_peer",
-                        help="WFD peer selector for --protocol wfd: index, MAC, or name")
-    parser.add_argument("--wfd-dry-run", action="store_true", dest="wfd_dry_run",
-                        help="Print WFD connection D-Bus call without activating it")
-    parser.add_argument("--wfd-test-pattern", action="store_true", dest="wfd_test_pattern",
-                        help="For --protocol wfd, stream generated test video instead of the desktop")
-    parser.add_argument("--wfd-media-pipeline", default="auto",
-                        choices=["auto", "ffmpeg", "gst"],
-                        dest="wfd_media_pipeline",
-                        help="For --protocol wfd, RTP media sender: auto (gst for test-pattern, ffmpeg for desktop), ffmpeg, or gst")
-    parser.add_argument("--wfd-capture-backend", default="auto", dest="wfd_capture_backend",
-                        choices=["auto", "portal", "wf-recorder", "x11grab"],
-                        help="Desktop capture backend for --protocol wfd: auto (default), portal, wf-recorder, or x11grab")
-    parser.add_argument("--wfd-latency-log", nargs="?", const="/tmp/fluxcast-wfd-latency.jsonl",
-                        default=None, dest="wfd_latency_log",
-                        help="For --protocol wfd, JSONL file path for latency/session logging "
-                             "(default: /tmp/fluxcast-wfd-latency.jsonl)")
-    parser.add_argument("--wfd-no-audio", action="store_true", dest="wfd_no_audio",
-                        help="For --protocol wfd, stream video only")
-    parser.add_argument("--wfd-audio-device", default=None, dest="wfd_audio_device",
-                        help="Pulse/PipeWire monitor source for --protocol wfd audio")
-    parser.add_argument("--wfd-rtsp-port", type=int, default=7236, dest="wfd_rtsp_port",
-                        help="RTSP port advertised in WFD IEs (default: 7236)")
-    parser.add_argument("--wfd-rtp-source-port", type=int, default=19002, dest="wfd_rtp_source_port",
-                        help="Local RTP source port for --protocol wfd (default: 19002)")
-    parser.add_argument("--wfd-interface", default=None, dest="wfd_interface",
-                        help="Wi-Fi interface to use for --wfd-scan, e.g. wlan0")
-    parser.add_argument("--wfd-timeout", type=int, default=8, dest="wfd_timeout",
-                        help="Wi-Fi Direct scan timeout in seconds (default: 8)")
-    parser.add_argument("--wfd-monitor", default=None, dest="wfd_monitor",
-                        help="Monitor name for WFD capture, e.g. eDP-1 (skips interactive picker)")
-    parser.add_argument("--device-name", default=None, dest="device_name",
-                        help="Pre-select DLNA/Cast device by friendly name (skips interactive picker)")
-    parser.add_argument("--monitor", default=None, dest="monitor_name",
-                        help="Pre-select monitor by name for DLNA/Cast capture, e.g. eDP-1 (skips picker)")
-    parser.add_argument("--tray", action="store_true",
-                        help="Launch system tray interface (no terminal needed)")
+
+    # General Options
+    general = parser.add_argument_group("General Options")
+    general.add_argument("--protocol", default="wfd",
+                         choices=["dlna", "cast", "wfd"],
+                         help="Connection protocol: wfd (Miracast, default), "
+                              "dlna (UPnP fallback), or cast (Chromecast built-in)")
+    # DLNA / Cast Options
+    dlna_cast = parser.add_argument_group("DLNA / Cast Options")
+    dlna_cast.add_argument("--tv-ip", default=None, dest="tv_ip",
+                           help="TV IP address (only applicable for --protocol cast)")
+    dlna_cast.add_argument("--host", default=None,
+                           help="LAN IP to advertise in the stream URL (default: auto)")
+    dlna_cast.add_argument("--port", type=int, default=8080,
+                           help="HTTP server port (default: 8080)")
+    dlna_cast.add_argument("--output-res", default=None, dest="output_res",
+                           help="Scale output to WxH, e.g. 1920x1080 (default: native)")
+    dlna_cast.add_argument("--fps", type=int, default=30,
+                           help="Frames per second (default: 30)")
+    dlna_cast.add_argument("--bitrate", default="4M",
+                           help="Video bitrate (default: 4M)")
+    dlna_cast.add_argument("--discover-timeout", type=int, default=5,
+                           dest="discover_timeout",
+                           help="Discovery timeout in seconds (default: 5)")
+    dlna_cast.add_argument("--capture-backend", default="auto", dest="capture_backend",
+                           choices=["auto", "wf-recorder", "x11grab"],
+                           help="Desktop capture backend for dlna/cast: auto (default), wf-recorder, or x11grab")
+    dlna_cast.add_argument("--transport", default="progressive-ts",
+                           choices=["progressive-ts", "hls", "live-ts"],
+                           help="DLNA stream transport: progressive-ts for low latency "
+                                "(default), hls as a stable fallback, or live-ts experimental")
+    # Wi-Fi Display (Miracast) Options
+    wfd = parser.add_argument_group("Wi-Fi Display (Miracast) Options")
+    wfd.add_argument("--doctor", action="store_true",
+                     help="Print passive Linux/WFD capability diagnostics and exit")
+    wfd.add_argument("--doctor-json", action="store_true", dest="doctor_json",
+                     help="Print diagnostics as JSON and exit")
+    wfd.add_argument("--wfd-scan", action="store_true", dest="wfd_scan",
+                     help="Run active Wi-Fi Direct discovery and exit")
+    wfd.add_argument("--wfd-peer", default=None, dest="wfd_peer",
+                     help="WFD peer selector for --protocol wfd: index, MAC, or name")
+    wfd.add_argument("--wfd-dry-run", action="store_true", dest="wfd_dry_run",
+                     help="Print WFD connection D-Bus call without activating it")
+    wfd.add_argument("--wfd-test-pattern", action="store_true", dest="wfd_test_pattern",
+                     help="For --protocol wfd, stream generated test video instead of the desktop")
+    wfd.add_argument("--wfd-media-pipeline", default="auto",
+                     choices=["auto", "ffmpeg", "gst"],
+                     dest="wfd_media_pipeline",
+                     help="For --protocol wfd, RTP media sender: auto (gst for test-pattern, ffmpeg for desktop), ffmpeg, or gst")
+    wfd.add_argument("--wfd-capture-backend", default="auto", dest="wfd_capture_backend",
+                     choices=["auto", "portal", "wf-recorder", "x11grab"],
+                     help="Desktop capture backend for --protocol wfd: auto (default), portal, wf-recorder, or x11grab")
+    wfd.add_argument("--wfd-latency-log", nargs="?", const="/tmp/fluxcast-wfd-latency.jsonl",
+                     default=None, dest="wfd_latency_log",
+                     help="For --protocol wfd, JSONL file path for latency/session logging "
+                          "(default: /tmp/fluxcast-wfd-latency.jsonl)")
+    wfd.add_argument("--wfd-no-audio", action="store_true", dest="wfd_no_audio",
+                     help="For --protocol wfd, stream video only")
+    wfd.add_argument("--wfd-audio-device", default=None, dest="wfd_audio_device",
+                     help="Pulse/PipeWire monitor source for --protocol wfd audio")
+    wfd.add_argument("--wfd-rtsp-port", type=int, default=7236, dest="wfd_rtsp_port",
+                     help="RTSP port advertised in WFD IEs (default: 7236)")
+    wfd.add_argument("--wfd-rtp-source-port", type=int, default=19002, dest="wfd_rtp_source_port",
+                     help="Local RTP source port for --protocol wfd (default: 19002)")
+    wfd.add_argument("--wfd-interface", default=None, dest="wfd_interface",
+                     help="Wi-Fi interface to use for --wfd-scan, e.g. wlan0")
+    wfd.add_argument("--wfd-timeout", type=int, default=8, dest="wfd_timeout",
+                     help="Wi-Fi Direct scan timeout in seconds (default: 8)")
+    wfd.add_argument("--wfd-monitor", default=None, dest="wfd_monitor",
+                     help="Monitor name for WFD capture, e.g. eDP-1 (skips interactive picker)")
+    dlna_cast.add_argument("--device-name", default=None, dest="device_name",
+                           help="Pre-select DLNA/Cast device by friendly name (skips interactive picker)")
+    dlna_cast.add_argument("--monitor", default=None, dest="monitor_name",
+                           help="Pre-select monitor by name for DLNA/Cast capture, e.g. eDP-1 (skips picker)")
+    general.add_argument("--tray", action="store_true",
+                         help="Launch system tray interface (no terminal needed)")
     return parser.parse_args()
 
 


### PR DESCRIPTION
## Summary

Fixes #27

Organize CLI arguments into logical groups in the `--help` output.

## Changes

**src/main.py** — Added three argument groups:
- **General Options**: `--protocol`, `--tray`
- **DLNA / Cast Options**: `--tv-ip`, `--host`, `--port`, `--output-res`, `--fps`, `--bitrate`, `--discover-timeout`, `--capture-backend`, `--transport`, `--device-name`, `--monitor`
- **Wi-Fi Display (Miracast) Options**: `--doctor`, `--doctor-json`, `--wfd-scan`, `--wfd-peer`, `--wfd-dry-run`, `--wfd-test-pattern`, `--wfd-media-pipeline`, `--wfd-capture-backend`, `--wfd-latency-log`, `--wfd-no-audio`, `--wfd-audio-device`, `--wfd-rtsp-port`, `--wfd-rtp-source-port`, `--wfd-interface`, `--wfd-timeout`, `--wfd-monitor`

## Before/After

**Before:** All arguments listed in a single flat list, hard to scan.

**After:**
```
FluxCast — stream your Arch Linux desktop to a Smart TV

General Options:
  --protocol {dlna,cast,wfd}
  --tray

DLNA / Cast Options:
  --tv-ip TV_IP
  --host HOST
  --port PORT
  ...

Wi-Fi Display (Miracast) Options:
  --doctor
  --wfd-scan
  --wfd-peer WFD_PEER
  ...
```

## Test plan

- [ ] Run `python src/main.py --help` and verify the grouped output
- [ ] Verify all arguments still work correctly
- [ ] No functional changes, only help text organization

---
