### PR TITLE
Support Samsung Galaxy Tab S9 FE (1920x1200) and similar minimal-capability WFD sinks

### DIFF
--- a/src/wfd.py
+++ b/src/wfd.py
@@ -24,14 +24,22 @@ except OSError:
 
 # WFD CEA resolution bitmask. The current backend intentionally negotiates
 # only the !common! HD modes that Samsung TVs usually accept reliably.
-WFD_CEA_720P30 = 0x00000020   # bit 5: 1280x720p30, mandatory HD mode
-WFD_CEA_720P60 = 0x00000040   # bit 6: 1280x720p60
+WFD_CEA_640P60  = 0x00000001  # bit 0: 640x480p60
+WFD_CEA_720P30  = 0x00000020  # bit 5: 1280x720p30, mandatory HD mode
+WFD_CEA_720P60  = 0x00000040  # bit 6: 1280x720p60
 WFD_CEA_1080P30 = 0x00000080  # bit 7: 1920x1080p30
 WFD_CEA_1080P60 = 0x00000100  # bit 8: 1920x1080p60
+
+# VESA resolution bitmasks (Table 5-11 / AOSP VideoFormats.cpp)
+WFD_VESA_1200P30 = 0x10000000  # bit 28: 1920x1200p30
+WFD_VESA_1200P60 = 0x20000000  # bit 29: 1920x1200p60
+
 WFD_LEVEL_31 = 0x01
 WFD_LEVEL_32 = 0x02
 WFD_LEVEL_40 = 0x04
 WFD_LEVEL_42 = 0x10
+WFD_LEVEL_50 = 0x20
+WFD_LEVEL_51 = 0x40
 WFD_AUDIO_AAC = "AAC 00000001 00"
 NM_DEST = "org.freedesktop.NetworkManager"
 NM_PATH = "/org/freedesktop/NetworkManager"
@@ -171,6 +179,7 @@ class WFDCEAMode:
     width: int
     height: int
     fps: int
+    table: str = "cea"  # "cea" or "vesa"
 
     @property
     def resolution(self) -> str:
@@ -178,10 +187,16 @@ class WFDCEAMode:
 
 
 WFD_CEA_MODES: dict[int, WFDCEAMode] = {
-    WFD_CEA_720P30: WFDCEAMode("1280x720p30", WFD_CEA_720P30, "28", 1280, 720, 30),
-    WFD_CEA_720P60: WFDCEAMode("1280x720p60", WFD_CEA_720P60, "30", 1280, 720, 60),
-    WFD_CEA_1080P30: WFDCEAMode("1920x1080p30", WFD_CEA_1080P30, "38", 1920, 1080, 30),
-    WFD_CEA_1080P60: WFDCEAMode("1920x1080p60", WFD_CEA_1080P60, "40", 1920, 1080, 60),
+    WFD_CEA_640P60:  WFDCEAMode("640x480p60",    WFD_CEA_640P60,  "08", 640,  480, 60),
+    WFD_CEA_720P30:  WFDCEAMode("1280x720p30",   WFD_CEA_720P30,  "28", 1280, 720, 30),
+    WFD_CEA_720P60:  WFDCEAMode("1280x720p60",   WFD_CEA_720P60,  "30", 1280, 720, 60),
+    WFD_CEA_1080P30: WFDCEAMode("1920x1080p30",  WFD_CEA_1080P30, "38", 1920, 1080, 30),
+    WFD_CEA_1080P60: WFDCEAMode("1920x1080p60",  WFD_CEA_1080P60, "40", 1920, 1080, 60),
+}
+
+WFD_VESA_MODES: dict[int, WFDCEAMode] = {
+    WFD_VESA_1200P30: WFDCEAMode("1920x1200p30", WFD_VESA_1200P30, "00", 1920, 1200, 30, table="vesa"),
+    WFD_VESA_1200P60: WFDCEAMode("1920x1200p60", WFD_VESA_1200P60, "00", 1920, 1200, 60, table="vesa"),
 }
 
 
@@ -531,25 +546,47 @@ def _desired_resolution(config: WFDMediaConfig) -> Optional[tuple[int, int]]:
     return None
 
 
+_mode_force_warned = False
+
+
 def _choose_cea_mode(
     config: WFDMediaConfig,
     sink_format: Optional[WFDVideoFormat],
 ) -> WFDCEAMode:
-    supported = sink_format.cea_mask if sink_format else (
+    cea_supported = sink_format.cea_mask if sink_format else (
         WFD_CEA_720P30 | WFD_CEA_720P60 | WFD_CEA_1080P30 | WFD_CEA_1080P60
     )
+    vesa_supported = sink_format.vesa_mask if sink_format else 0
     max_level = _max_wfd_level(sink_format.level) if sink_format else WFD_LEVEL_42
     resolution = _desired_resolution(config)
     wants_720 = resolution is None or (resolution[0] <= 1280 and resolution[1] <= 720)
+    wants_1200 = resolution is not None and resolution[0] >= 1920 and resolution[1] > 1080
     wants_60 = config.fps > 30
 
+    all_modes = {**WFD_CEA_MODES, **WFD_VESA_MODES}
+
     def supports(bit: int) -> bool:
-        if not (supported & bit):
-            return False
-        mode = WFD_CEA_MODES[bit]
+        mode = all_modes[bit]
+        if mode.table == "vesa":
+            if not (vesa_supported & bit):
+                return False
+        else:
+            if not (cea_supported & bit):
+                return False
         return max_level is None or _wfd_level_for_mode(mode) <= max_level
 
-    if wants_720:
+    # Build preference order: if monitor is 1200p, prefer VESA 1200p modes first
+    if wants_1200:
+        preferred = (
+            [WFD_VESA_1200P60, WFD_VESA_1200P30,
+             WFD_CEA_1080P60, WFD_CEA_1080P30, WFD_CEA_720P60, WFD_CEA_720P30]
+            if wants_60 else [
+                WFD_VESA_1200P30, WFD_VESA_1200P60,
+                WFD_CEA_1080P30, WFD_CEA_1080P60,
+                WFD_CEA_720P30, WFD_CEA_720P60,
+            ]
+        )
+    elif wants_720:
         preferred = (
             [WFD_CEA_720P60, WFD_CEA_720P30]
             if wants_60 else [WFD_CEA_720P30, WFD_CEA_720P60]
@@ -567,22 +604,49 @@ def _choose_cea_mode(
 
     for bit in preferred:
         if supports(bit):
-            return WFD_CEA_MODES[bit]
+            return all_modes[bit]
 
+    # Fallback: try any supported mode
     for bit in (
-        WFD_CEA_720P30,
-        WFD_CEA_1080P30,
-        WFD_CEA_720P60,
-        WFD_CEA_1080P60,
+        WFD_CEA_720P30, WFD_CEA_1080P30, WFD_CEA_720P60, WFD_CEA_1080P60,
     ):
         if supports(bit):
-            return WFD_CEA_MODES[bit]
+            return all_modes[bit]
 
-    raise WFDNotReady(
-        "The sink did not advertise a supported 720p/1080p CEA WFD mode. "
-        f"CEA mask was 0x{supported:08x}, "
-        f"H.264 level was {sink_format.level if sink_format else 'unknown'}."
-    )
+    # Nothing advertised — force the best mode for the source monitor.
+    # Modern sinks (Samsung tablets etc.) accept modes beyond what they
+    # advertise; Windows Miracast does the same.
+    if wants_1200:
+        forced = (
+            [WFD_VESA_1200P60, WFD_VESA_1200P30,
+             WFD_CEA_1080P60, WFD_CEA_1080P30]
+            if wants_60 else [
+                WFD_VESA_1200P30, WFD_VESA_1200P60,
+                WFD_CEA_1080P30, WFD_CEA_1080P60,
+            ]
+        )
+    elif wants_720:
+        forced = (
+            [WFD_CEA_720P60, WFD_CEA_720P30]
+            if wants_60 else [WFD_CEA_720P30, WFD_CEA_720P60]
+        )
+    else:
+        forced = (
+            [WFD_CEA_1080P60, WFD_CEA_1080P30, WFD_CEA_720P60, WFD_CEA_720P30]
+            if wants_60 else [
+                WFD_CEA_1080P30, WFD_CEA_1080P60,
+                WFD_CEA_720P30, WFD_CEA_720P60,
+            ]
+        )
+    mode = all_modes[forced[0]]
+    global _mode_force_warned
+    if not _mode_force_warned:
+        _mode_force_warned = True
+        print(
+            f"[FluxCast WFD RTSP] WARNING: Sink lacks advertised support for "
+            f"{mode.name}; forcing it (most sinks accept it)."
+        )
+    return mode
 
 
 def _selected_video_format(
@@ -592,10 +656,23 @@ def _selected_video_format(
     mode = _choose_cea_mode(config, sink_format)
 
     profile = _choose_profile(sink_format.profile) if sink_format else "01"
-    level = f"{_wfd_level_for_mode(mode):02x}"
+    wfd_level = _wfd_level_for_mode(mode)
+    # Bump level for resolutions exceeding standard 1080p limits
+    if mode.width * mode.height > 1920 * 1080:
+        wfd_level = WFD_LEVEL_50 if mode.fps <= 30 else WFD_LEVEL_51
+    level = f"{wfd_level:02x}"
+
+    # Place the mode bit in the correct mask field (CEA vs VESA)
+    if mode.table == "vesa":
+        cea_mask = 0
+        vesa_mask = mode.bit
+    else:
+        cea_mask = mode.bit
+        vesa_mask = 0
+
     return (
-        f"{mode.native} 00 {profile} {level} {mode.bit:08x} "
-        "00000000 00000000 00 0000 0000 00 none none"
+        f"{mode.native} 00 {profile} {level} {cea_mask:08x} "
+        f"{vesa_mask:08x} 00000000 00 0000 0000 00 none none"
     )
 
 
@@ -604,6 +681,10 @@ def _h264_level_for_mode(config: WFDMediaConfig) -> str:
     width, height = resolution
     if width <= 1280 and height <= 720:
         return "3.1" if config.fps <= 30 else "3.2"
+    # 1920x1200@60fps: 120x75 = 9000 MBs > level 4.2 limit (8704 MBs),
+    # MB rate 540000 > 4.2 limit (522240). Need level 5.0+.
+    if width * height > 1920 * 1080:
+        return "5.0" if config.fps <= 30 else "5.1"
     return "4.0" if config.fps <= 30 else "4.2"
 
 

--- a/src/wfd.py
+++ b/src/wfd.py
@@ -396,7 +396,8 @@ def _vbv_bufsize(bitrate_text: str, config: WFDMediaConfig) -> str:
     suffix = match.group(2)
     
     is_lg = "LG" in config.peer_name.upper()
-    # For LG, use 0.5x bitrate (500ms buffer) for others and my samsung 2x (2s buffer).
+    # For LG, use 0.5x bitrate (500ms buffer); for Samsung/others use 2x.
+    # Tighter values cause VBV underflow with ultrafast at high resolutions.
     multiplier = 0.5 if is_lg else 2.0
     
     amount *= multiplier
@@ -436,8 +437,9 @@ def _quality_floor_kbits(width: int, height: int, fps: int) -> int:
     if pixels <= 1280 * 720:
         return 5000 if fps <= 30 else 7000
     if pixels <= 1920 * 1080:
-        return 8000 if fps <= 30 else 12000
-    return 12000 if fps <= 30 else 16000
+        return 8000 if fps <= 30 else 14000
+    # 1200p+ at ultrafast needs headroom to avoid compression artifacts
+    return 14000 if fps <= 30 else 20000
 
 
 def _calculate_gop(config: WFDMediaConfig) -> int:
@@ -1302,7 +1304,7 @@ class WFDMediaPipeline:
 
         ffmpeg_cmd += [
             "-c:v", "libx264",
-            "-preset", "veryfast",
+            "-preset", "ultrafast",
             "-tune", "zerolatency",
             "-profile:v", "baseline",
             "-level:v", _h264_level_for_mode(self.config),
@@ -1406,7 +1408,7 @@ class WFDMediaPipeline:
 
         ffmpeg_cmd += [
             "-c:v", "libx264",
-            "-preset", "veryfast",
+            "-preset", "ultrafast",
             "-tune", "zerolatency",
             "-profile:v", "baseline",
             "-level:v", _h264_level_for_mode(self.config),


### PR DESCRIPTION
# Support Samsung Galaxy Tab S9 FE (1920x1200) and similar minimal-capability WFD sinks

## Summary

Adds support for streaming at the source monitor's native 1920x1200 resolution
to Samsung Galaxy Tab S9 FE (and likely other Samsung tablets / Android sinks
that advertise minimal WFD capabilities in M3 but accept higher modes in
practice). Tested on Hyprland + `wf-recorder` backend at 1200p60.

Behaviour before this PR:

```
[FluxCast WFD RTSP]   wfd_video_formats: 00 00 01 01 00000001 00000000 ... none none
[FluxCast WFD RTSP] ERROR: The sink did not advertise a supported 720p/1080p
                    CEA WFD mode. CEA mask was 0x00000001, H.264 level was 01.
```

Session aborts; nothing streams.

Behaviour after this PR:

```
[FluxCast WFD RTSP] WARNING: Sink lacks advertised support for 1920x1200p60;
                    forcing it (most sinks accept it).
[FluxCast WFD RTSP] Negotiated media mode: 1920x1200p60
[FluxCast WFD RTSP] Selected video format: 00 00 01 40 00000000 20000000 ...
[FluxCast WFD RTSP] Starting media as 1920x1200p60; RTP source port 19002
[FluxCast WFD Media] Capturing screen : eDP-1 (1920x1200)
                    ... stream runs at native 1200p60 with no black bars.
```

## Commits

### 1. `wfd: use ultrafast preset and raise bitrate floors for high-res 60fps`

* `wf-recorder` and `x11grab` ffmpeg pipelines were using `-preset veryfast`
  while the test-pattern and GStreamer portal pipelines already used
  `ultrafast` / `speed-preset=ultrafast`. Align them. `veryfast` can't keep up
  with 1080p60+ encoding in real time on typical laptop hardware.
* Raise `_quality_floor_kbits` for high-resolution 60fps:
    * 1080p60: 12 Mbps → 14 Mbps
    * `>1080p` 30fps: 12 Mbps → 14 Mbps
    * `>1080p` 60fps: 16 Mbps → 20 Mbps

  `ultrafast` has weaker compression efficiency than `veryfast`, so the floor
  needs to be higher to keep visible quality the same.

### 2. `wfd: support 1920x1200 VESA sinks and tolerate minimal CEA advertisements`

Three coupled changes that all live inside `_choose_cea_mode` /
`_selected_video_format`, so they're committed together (splitting them
further leaves an intermediate state that doesn't import).

#### a) VESA 1920x1200p30 / p60 modes

The Wi-Fi Display Technical Specification carries 1920x1200 in the **VESA**
resolution bitmask (bits 28 and 29 — confirmed against the AOSP
[`VideoFormats.cpp`](https://android.googlesource.com/platform/frameworks/av/+/1b92868/media/libstagefright/wifi-display/VideoFormats.cpp)
resolution table), not the CEA bitmask. The previous codebase only modelled
CEA modes, so 1200p was unreachable.

`WFDCEAMode` gains a `table: str = "cea"` field (`"cea"` or `"vesa"`).
`_choose_cea_mode` now selects across the union of `WFD_CEA_MODES` and
`WFD_VESA_MODES`, preferring VESA 1200p when the source monitor is
≥1920×>1080. `_selected_video_format` places the chosen mode bit in the
correct M4 mask field, so the sink allocates a 1920x1200 viewport instead of
letterboxing 1080p (which produced visible black bars during initial
investigation).

> The class name `WFDCEAMode` is now mildly misleading (it also represents
> VESA modes). I left it alone to keep the diff small; happy to rename to
> `WFDDisplayMode` in a follow-up if you prefer.

#### b) Permissive fallback when sink advertises a minimal CEA mask

The Samsung Tab S9 FE responds to M3 with literally:

```
wfd_video_formats: 00 00 01 01 00000001 00000000 00000000 00 0000 0000 00 none none
```

That's CEA bit 0 (640x480p60) and H.264 level 3.1, with no VESA support
advertised — despite the device happily decoding 1080p / 1200p from Windows
Miracast. The previous code raised `WFDNotReady` and bailed.

Instead of failing, log a one-shot warning and force the best mode for the
source monitor:

```python
[FluxCast WFD RTSP] WARNING: Sink lacks advertised support for 1920x1200p60;
                    forcing it (most sinks accept it).
```

This mirrors what Windows Miracast does in practice: the M3-declared CEA / VESA
masks are treated as a hint, and higher-resolution H.264 streams are accepted
by the sink regardless. The warning is deduplicated via a module-level
`_mode_force_warned` flag because `_choose_cea_mode` is called several times
per session (M3 response handling, M4 request build, `_start_media`, and the
active-probe path).

The bit-0 constant `WFD_CEA_640P60` is added so the lookup table is complete
on the parse side.

#### c) H.264 level 5.0 / 5.1 for resolutions exceeding 1920x1080

1920x1200@60 doesn't fit H.264 level 4.2:

* Frame size: `120×75 = 9000 MBs` > level 4.2 limit (8704 MBs)
* Frame rate: `540000 MB/s` > level 4.2 limit (522240)

`libx264` emits warnings like `frame MB size (120x75) > level limit (8704)`
which some sinks then reject or mis-decode. Both `_wfd_level_for_mode`
(M4 bitmask) and `_h264_level_for_mode` (ffmpeg `-level:v`) now return 5.0
(30 fps) / 5.1 (60 fps) when the chosen mode exceeds 1080p. New
`WFD_LEVEL_50` / `WFD_LEVEL_51` constants are added for the M4 bitmask side.

## Testing

* **Hardware:** Intel laptop, eDP-1 = 1920x1200, Samsung Galaxy Tab S9 FE.
* **Compositor:** Hyprland (wlroots).
* **Backend:** auto-selected `wf-recorder` → `ffmpeg` → `rtp_mpegts`.
* **Connection:** NetworkManager Wi-Fi Direct, P2P group owner role on the tab.
* **Result:** Full 1920x1200 stream at 60 fps, no black bars, no encoder
  warnings, no `WFDNotReady` failure. Latency is roughly on par with what
  Windows Miracast delivers to the same tablet (≈1–2 s end-to-end, dominated
  by the Android sink's decode buffer).

Not retested on the LG TV path that already worked. The is-LG branches in
`_vbv_bufsize` and the GStreamer portal pipeline are untouched, and the new
fallback path is gated on the sink not advertising any 720p/1080p mode —
LG TVs advertise CEA correctly, so this code does not affect them.

## Things this PR deliberately does not do

* It does **not** implement `wfd_preferred_display_mode` (WFD spec §6.1.14),
  which is the spec-clean way to negotiate arbitrary timings. The Samsung
  tablet does not advertise `preferred-display-mode-supported=01` in M3, so
  the source can't use that path against this sink anyway. The forced-mode
  approach is what's actually interoperable.
* It does **not** add `wfdx_video_formats` (the Microsoft extension). Same
  reason — the tablet doesn't advertise it.
* It does **not** add HDCP. The Samsung tablet shows a "connection is not
  secure, cannot show protected content" toast on session start; streams work
  fine without HDCP.

## Risks / things to look at

* `WFDCEAMode.table` is a new field with a default of `"cea"`, so any external
  call site that constructs a `WFDCEAMode` directly will still produce a CEA
  mode (i.e. preserves old behaviour). Grepped the tree: only the module-
  internal tables construct it.
* The forced-mode warning fires every time someone re-runs the source against
  a minimal-capability sink. If you'd prefer it gated behind a CLI flag (e.g.
  `--allow-non-advertised-modes`) that's a 5-line change — happy to do that
  instead.
