### PR TITLE
Add per-mode tray configuration

### DIFF
--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -92,6 +92,51 @@ python3 src/main.py --protocol cast
   - Requires `libappindicator` (Hyprland/KDE) or `gnome-shell-extension-appindicator` (GNOME).
   - On non-Hyprland Wayland (KDE, GNOME), WFD capture uses the xdg-desktop-portal screen picker dialog.
 
+#### Per-mode tray configuration
+
+Tray launches can override stream defaults with an INI file at
+`$XDG_CONFIG_HOME/fluxcast/config`, or `~/.config/fluxcast/config` when
+`XDG_CONFIG_HOME` is not set. This file affects only the tray; direct CLI
+commands keep their normal behavior.
+
+```ini
+[wfd]
+output-res = 1920x1080
+fps = 60
+bitrate = 8M
+wfd-no-audio = false
+
+[dlna]
+transport = hls
+fps = 30
+bitrate = 4M
+
+[cast]
+bitrate = 4M
+```
+
+All modes accept `output-res`, `fps`, and `bitrate`. The `dlna` and `cast`
+sections also accept `host`, `port`, `discover-timeout`, `transport`, and
+`capture-backend`. The `wfd` section accepts these WFD stream/session options:
+
+- `wfd-test-pattern`
+- `wfd-media-pipeline`
+- `wfd-capture-backend`
+- `wfd-latency-log`
+- `wfd-no-audio`
+- `wfd-audio-device`
+- `wfd-rtsp-port`
+- `wfd-no-firewall`
+- `wfd-rtp-source-port`
+- `wfd-interface`
+- `wfd-timeout`
+
+Boolean flags accept `true` or `false` (also `yes`/`no`, `on`/`off`, and
+`1`/`0`). A missing file, an empty file, or an omitted key keeps the built-in
+default. Invalid values and unknown keys are logged and ignored. Device, peer,
+monitor, and protocol selection remain controlled by the tray and cannot be
+overridden in this file.
+
 ### DLNA/Cast
 
 - `--host`, `--port`

--- a/src/tray.py
+++ b/src/tray.py
@@ -9,6 +9,8 @@ os.environ.setdefault("PYSTRAY_BACKEND", "appindicator")
 from PIL import Image
 import pystray
 
+from tray_config import load_profile
+
 _BASE = os.path.dirname(os.path.abspath(__file__))
 _ICON_PATH = os.path.join(_BASE, "assets", "flcast_logo_512x512.png")
 _MAIN = os.path.join(_BASE, "main.py")
@@ -243,11 +245,16 @@ def _rescan_all() -> None:
 
 # ── cast actions ──────────────────────────────────────────────────────────────
 
+def _profile_args(mode: str) -> list[str]:
+    return load_profile(mode, warn=lambda message: _log(f"config warning: {message}"))
+
+
 def _start_wfd(peer, monitor) -> None:
     cmd = [_PY, _MAIN, "--protocol", "wfd", "--wfd-peer", peer.address]
     # On non-Hyprland Wayland the WFD backend uses xdg-portal and shows its
     if monitor is not None and not _wfd_uses_portal():
         cmd += ["--monitor", monitor.name]
+    cmd += _profile_args("wfd")
     _launch(cmd, peer.name or peer.address)
 
 
@@ -255,6 +262,7 @@ def _start_dlna(device, monitor) -> None:
     cmd = [_PY, _MAIN, "--protocol", "dlna", "--device-name", device.friendly_name]
     if monitor is not None:
         cmd += ["--monitor", monitor.name]
+    cmd += _profile_args("dlna")
     _launch(cmd, device.friendly_name)
 
 
@@ -263,6 +271,7 @@ def _start_cast(device, monitor) -> None:
     cmd = [_PY, _MAIN, "--protocol", "cast", "--device-name", name]
     if monitor is not None:
         cmd += ["--monitor", monitor.name]
+    cmd += _profile_args("cast")
     _launch(cmd, name)
 
 

--- a/src/tray_config.py
+++ b/src/tray_config.py
@@ -1,0 +1,209 @@
+"""Validated per-mode configuration for FluxCast tray launches."""
+
+from __future__ import annotations
+
+import configparser
+import os
+import re
+import sys
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Callable
+
+
+Validator = Callable[[str], str | bool]
+WarningHandler = Callable[[str], None]
+
+
+@dataclass(frozen=True)
+class _Option:
+    validate: Validator
+    is_flag: bool = False
+
+
+def _choice(*choices: str) -> Validator:
+    allowed = set(choices)
+
+    def validate(value: str) -> str:
+        normalized = value.strip().lower()
+        if normalized not in allowed:
+            expected = ", ".join(choices)
+            raise ValueError(f"expected one of: {expected}")
+        return normalized
+
+    return validate
+
+
+def _positive_int(value: str) -> str:
+    try:
+        parsed = int(value.strip())
+    except ValueError as exc:
+        raise ValueError("expected a positive integer") from exc
+    if parsed <= 0:
+        raise ValueError("expected a positive integer")
+    return str(parsed)
+
+
+def _port(value: str) -> str:
+    parsed = int(_positive_int(value))
+    if parsed > 65535:
+        raise ValueError("expected a port from 1 to 65535")
+    return str(parsed)
+
+
+def _resolution(value: str) -> str:
+    match = re.fullmatch(r"\s*(\d+)[xX](\d+)\s*", value)
+    if match is None:
+        raise ValueError("expected WIDTHxHEIGHT, for example 1920x1080")
+    width, height = (int(part) for part in match.groups())
+    if width <= 0 or height <= 0:
+        raise ValueError("width and height must be greater than zero")
+    return f"{width}x{height}"
+
+
+def _bitrate(value: str) -> str:
+    normalized = value.strip()
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)([kKmMgG]?)", normalized)
+    if match is None:
+        raise ValueError("expected a positive number with an optional K, M, or G suffix")
+    try:
+        positive = Decimal(match.group(1)) > 0
+    except InvalidOperation as exc:
+        raise ValueError("expected a positive bitrate") from exc
+    if not positive:
+        raise ValueError("expected a positive bitrate")
+    return normalized
+
+
+def _text(value: str) -> str:
+    normalized = value.strip()
+    if not normalized or normalized.startswith("-"):
+        raise ValueError("expected a non-empty value that does not start with '-'")
+    return normalized
+
+
+def _boolean(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "yes", "true", "on"}:
+        return True
+    if normalized in {"0", "no", "false", "off"}:
+        return False
+    raise ValueError("expected true or false")
+
+
+_COMMON_OPTIONS = {
+    "output-res": _Option(_resolution),
+    "fps": _Option(_positive_int),
+    "bitrate": _Option(_bitrate),
+}
+
+_DLNA_CAST_OPTIONS = {
+    **_COMMON_OPTIONS,
+    "host": _Option(_text),
+    "port": _Option(_port),
+    "discover-timeout": _Option(_positive_int),
+    "transport": _Option(_choice("progressive-ts", "hls", "live-ts")),
+    "capture-backend": _Option(_choice("auto", "wf-recorder", "x11grab")),
+}
+
+_MODE_OPTIONS = {
+    "wfd": {
+        **_COMMON_OPTIONS,
+        "wfd-test-pattern": _Option(_boolean, is_flag=True),
+        "wfd-media-pipeline": _Option(_choice("auto", "ffmpeg", "gst")),
+        "wfd-capture-backend": _Option(
+            _choice("auto", "portal", "wf-recorder", "x11grab", "gst-x11")
+        ),
+        "wfd-latency-log": _Option(_text),
+        "wfd-no-audio": _Option(_boolean, is_flag=True),
+        "wfd-audio-device": _Option(_text),
+        "wfd-rtsp-port": _Option(_port),
+        "wfd-no-firewall": _Option(_boolean, is_flag=True),
+        "wfd-rtp-source-port": _Option(_port),
+        "wfd-interface": _Option(_text),
+        "wfd-timeout": _Option(_positive_int),
+    },
+    "dlna": _DLNA_CAST_OPTIONS,
+    "cast": _DLNA_CAST_OPTIONS,
+}
+
+
+def get_config_path() -> Path:
+    """Return the XDG-compliant tray config path."""
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(config_home).expanduser() if config_home else Path.home() / ".config"
+    return base / "fluxcast" / "config"
+
+
+def _default_warning(message: str) -> None:
+    print(f"[FluxCast tray config] WARNING: {message}", file=sys.stderr)
+
+
+def load_profile(
+    mode: str,
+    *,
+    config_path: str | os.PathLike[str] | None = None,
+    warn: WarningHandler | None = None,
+) -> list[str]:
+    """Load validated extra CLI arguments for a tray launch in ``mode``.
+
+    A missing file, an empty file, or a missing mode section returns an empty
+    list so tray launches retain their built-in defaults.
+    """
+    if mode not in _MODE_OPTIONS:
+        raise ValueError(f"unsupported tray mode: {mode}")
+
+    path = Path(config_path) if config_path is not None else get_config_path()
+    warning = warn if warn is not None else _default_warning
+
+    try:
+        contents = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        warning(f"could not read {path}: {exc}; using built-in defaults")
+        return []
+
+    if not contents.strip():
+        return []
+
+    # Treat [DEFAULT] like an ordinary, unused section: profiles must not
+    # inherit options because the config contract is explicitly per-mode.
+    parser = configparser.ConfigParser(
+        interpolation=None,
+        default_section="__fluxcast_defaults_are_not_supported__",
+    )
+    try:
+        parser.read_string(contents, source=str(path))
+    except configparser.Error as exc:
+        warning(f"could not parse {path}: {exc}; using built-in defaults")
+        return []
+
+    if not parser.has_section(mode):
+        return []
+
+    args: list[str] = []
+    options = _MODE_OPTIONS[mode]
+    for name, raw_value in parser.items(mode):
+        option = options.get(name)
+        if option is None:
+            warning(f"unknown option '{name}' in [{mode}]; ignoring it")
+            continue
+
+        try:
+            value = option.validate(raw_value)
+        except ValueError as exc:
+            warning(
+                f"invalid value for '{name}' in [{mode}]: {raw_value!r} "
+                f"({exc}); using the built-in default"
+            )
+            continue
+
+        if option.is_flag:
+            if value is True:
+                args.append(f"--{name}")
+        else:
+            args.extend((f"--{name}", str(value)))
+
+    return args

--- a/tests/test_tray_config.py
+++ b/tests/test_tray_config.py
@@ -1,0 +1,151 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import tray_config  # noqa: E402
+
+
+class TrayConfigTest(unittest.TestCase):
+    def setUp(self):
+        self._temp_dir = tempfile.TemporaryDirectory()
+        self.config_path = Path(self._temp_dir.name) / "config"
+
+    def tearDown(self):
+        self._temp_dir.cleanup()
+
+    def _write(self, contents):
+        self.config_path.write_text(contents, encoding="utf-8")
+
+    def test_missing_and_empty_config_preserve_defaults(self):
+        self.assertEqual(
+            tray_config.load_profile("wfd", config_path=self.config_path),
+            [],
+        )
+        self._write("\n")
+        self.assertEqual(
+            tray_config.load_profile("dlna", config_path=self.config_path),
+            [],
+        )
+
+    def test_loads_only_selected_mode(self):
+        self._write(
+            """
+[wfd]
+output-res = 1920X1080
+fps = 60
+bitrate = 8M
+wfd-no-audio = true
+wfd-no-firewall = false
+
+[dlna]
+fps = invalid-in-unselected-section
+"""
+        )
+        warnings = []
+
+        args = tray_config.load_profile(
+            "wfd", config_path=self.config_path, warn=warnings.append
+        )
+
+        self.assertEqual(
+            args,
+            [
+                "--output-res", "1920x1080",
+                "--fps", "60",
+                "--bitrate", "8M",
+                "--wfd-no-audio",
+            ],
+        )
+        self.assertEqual(warnings, [])
+
+    def test_does_not_inherit_options_from_default_section(self):
+        self._write(
+            """
+[DEFAULT]
+fps = 60
+
+[wfd]
+bitrate = 8M
+"""
+        )
+
+        self.assertEqual(
+            tray_config.load_profile("wfd", config_path=self.config_path),
+            ["--bitrate", "8M"],
+        )
+
+    def test_loads_dlna_stream_options(self):
+        self._write(
+            """
+[dlna]
+transport = HLS
+capture-backend = wf-recorder
+host = 192.168.1.20
+port = 9090
+discover-timeout = 10
+"""
+        )
+
+        self.assertEqual(
+            tray_config.load_profile("dlna", config_path=self.config_path),
+            [
+                "--transport", "hls",
+                "--capture-backend", "wf-recorder",
+                "--host", "192.168.1.20",
+                "--port", "9090",
+                "--discover-timeout", "10",
+            ],
+        )
+
+    def test_invalid_and_unknown_options_warn_and_fall_back(self):
+        self._write(
+            """
+[wfd]
+output-res = full-hd
+fps = 0
+bitrate = fast
+wfd-rtsp-port = 70000
+wfd-no-audio = sometimes
+wfd-peer = living-room-tv
+"""
+        )
+        warnings = []
+
+        args = tray_config.load_profile(
+            "wfd", config_path=self.config_path, warn=warnings.append
+        )
+
+        self.assertEqual(args, [])
+        self.assertEqual(len(warnings), 6)
+        self.assertTrue(any("unknown option 'wfd-peer'" in item for item in warnings))
+        self.assertTrue(any("invalid value for 'fps'" in item for item in warnings))
+
+    def test_malformed_config_warns_and_preserves_defaults(self):
+        self._write("fps = 60\n")
+        warnings = []
+
+        args = tray_config.load_profile(
+            "cast", config_path=self.config_path, warn=warnings.append
+        )
+
+        self.assertEqual(args, [])
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("could not parse", warnings[0])
+
+    def test_uses_xdg_config_home(self):
+        with mock.patch.dict(
+            os.environ, {"XDG_CONFIG_HOME": "/tmp/fluxcast-test-config"}
+        ):
+            self.assertEqual(
+                tray_config.get_config_path(),
+                Path("/tmp/fluxcast-test-config/fluxcast/config"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an XDG-compliant, per-mode INI configuration file for tray launches. Tray users can override stream defaults without changing direct CLI behavior, while invalid or unknown options are logged and ignored. Missing files, empty files, and omitted keys preserve today’s defaults.

## Background

The tray currently always launches WFD, DLNA, and Cast with built-in defaults, so users must switch to the CLI to change resolution, FPS, or bitrate.

Closes #65

## Changes

- add `src/tray_config.py` with per-mode whitelists, value validation, boolean flag handling, and safe warnings
- append validated profile arguments to WFD, DLNA, and Cast tray commands
- add seven regression tests for defaults, mode isolation, malformed input, validation, and XDG path resolution
- document the config path, INI format, accepted keys, and fallback behavior

## Testing

- `python3 -m unittest tests.test_tray_config -v` — 7 passed
- `python3 -m compileall -q src tests` — passed
- `git diff --check origin/dev...HEAD` — passed
- `python3 -m unittest discover -s tests -v` — 15 passed; 2 unchanged firewall diagnostics tests fail on macOS because their mocks expect Linux firewalld ordering

## Additional Notes

The whitelist follows the CLI flags currently available on `dev`. The issue example mentions `wfd-uibc`, but that flag has not landed on `dev`; it is therefore reported as unknown instead of being forwarded to an argparse version that would reject it.