### PR TITLE
fix(doctor): probe the firewalld port instead of always warning

### DIFF
--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -519,25 +519,37 @@ def _firewalld_check() -> Optional[Check]:
         return None
 
     try:
-        state = _run(["systemctl", "is-active", "firewalld"], timeout=3.0)
+        state = _run(["firewall-cmd", "--state"], timeout=3.0)
     except (OSError, subprocess.TimeoutExpired) as exc:
         return Check("firewall (firewalld)", STATUS_WARN, "could not query firewalld state", str(exc))
 
-    if state.stdout.strip() != "active":
+    if state.returncode != 0 or state.stdout.strip() != "running":
         return Check(
             "firewall (firewalld)",
             STATUS_OK,
             "firewalld is not running; port not blocked",
-            state.stdout.strip(),
+            (state.stdout + state.stderr).strip(),
         )
 
-    # Don't probe the port here: `firewall-cmd --query-port` can prompt for auth, and
-    # FluxCast opens the port automatically for the session anyway.
+    # `--query-port` is a read-only D-Bus getter; unlike `--add-port` it never
+    # prompts for authentication, so probing the port here is safe.
+    try:
+        query = _run(["firewall-cmd", f"--query-port={WFD_RTSP_PORT}/tcp"], timeout=3.0)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return Check("firewall (firewalld)", STATUS_WARN, "could not query firewalld port", str(exc))
+
+    if query.returncode == 0 and query.stdout.strip() == "yes":
+        return Check(
+            "firewall (firewalld)",
+            STATUS_OK,
+            f"firewalld is running and allows port {WFD_RTSP_PORT}",
+            (query.stdout + query.stderr).strip(),
+        )
     return Check(
         "firewall (firewalld)",
         STATUS_WARN,
-        f"firewalld is running; FluxCast opens port {WFD_RTSP_PORT}/tcp for the WFD session",
-        f"if the TV can't connect, open it yourself: sudo firewall-cmd --add-port={WFD_RTSP_PORT}/tcp --permanent && sudo firewall-cmd --reload",
+        f"firewalld is running but port {WFD_RTSP_PORT}/tcp is closed",
+        f"open it with: sudo firewall-cmd --add-port={WFD_RTSP_PORT}/tcp --permanent && sudo firewall-cmd --reload",
     )
 
 

--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -523,33 +523,55 @@ def _firewalld_check() -> Optional[Check]:
     except (OSError, subprocess.TimeoutExpired) as exc:
         return Check("firewall (firewalld)", STATUS_WARN, "could not query firewalld state", str(exc))
 
-    if state.returncode != 0 or state.stdout.strip() != "running":
+    # firewalld gates firewall-cmd through polkit, so on a headless/gated host
+    # `--state` and `--query-port` can fail with an authorization error rather
+    # than a real answer. Trust only what firewall-cmd literally prints: a
+    # non-zero exit is not proof the firewall is down, so an auth failure must
+    # never become a definitive OK-or-closed. Report "couldn't verify" instead.
+    state_out = state.stdout.strip()
+    state_all = (state.stdout + state.stderr).strip()
+    if state_out != "running":
+        if "not running" in state_all.lower():
+            return Check(
+                "firewall (firewalld)",
+                STATUS_OK,
+                "firewalld is not running; port not blocked",
+                state_all,
+            )
         return Check(
             "firewall (firewalld)",
-            STATUS_OK,
-            "firewalld is not running; port not blocked",
-            (state.stdout + state.stderr).strip(),
+            STATUS_WARN,
+            "could not verify firewalld state (firewall-cmd did not report running/not running)",
+            state_all,
         )
 
-    # `--query-port` is a read-only D-Bus getter; unlike `--add-port` it never
-    # prompts for authentication, so probing the port here is safe.
     try:
         query = _run(["firewall-cmd", f"--query-port={WFD_RTSP_PORT}/tcp"], timeout=3.0)
     except (OSError, subprocess.TimeoutExpired) as exc:
         return Check("firewall (firewalld)", STATUS_WARN, "could not query firewalld port", str(exc))
 
-    if query.returncode == 0 and query.stdout.strip() == "yes":
+    # `--query-port` prints `yes`/`no` (exit 0/1) for a real answer; anything
+    # else — empty output, an auth error — means we could not check the port.
+    query_out = query.stdout.strip()
+    if query_out == "yes":
         return Check(
             "firewall (firewalld)",
             STATUS_OK,
             f"firewalld is running and allows port {WFD_RTSP_PORT}",
             (query.stdout + query.stderr).strip(),
         )
+    if query_out == "no":
+        return Check(
+            "firewall (firewalld)",
+            STATUS_WARN,
+            f"firewalld is running but port {WFD_RTSP_PORT}/tcp is closed",
+            f"open it with: sudo firewall-cmd --add-port={WFD_RTSP_PORT}/tcp --permanent && sudo firewall-cmd --reload",
+        )
     return Check(
         "firewall (firewalld)",
         STATUS_WARN,
-        f"firewalld is running but port {WFD_RTSP_PORT}/tcp is closed",
-        f"open it with: sudo firewall-cmd --add-port={WFD_RTSP_PORT}/tcp --permanent && sudo firewall-cmd --reload",
+        f"could not verify whether firewalld allows port {WFD_RTSP_PORT}/tcp",
+        (query.stdout + query.stderr).strip(),
     )
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -61,6 +61,34 @@ class FirewallCheckTest(unittest.TestCase):
             check = diagnostics._firewall_check()
         self.assertEqual(check.status, diagnostics.STATUS_OK)
 
+    def test_firewalld_state_auth_failure_does_not_give_all_clear(self):
+        # polkit-gated `--state` fails with an auth error, not "not running";
+        # a non-zero exit must not be read as a clean firewall.
+        err = "Authorization failed.\n    Make sure polkit agent is running or run the application as superuser."
+        with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
+                mock.patch("diagnostics._run", return_value=_completed("", returncode=1, stderr=err)):
+            check = diagnostics._firewall_check()
+        self.assertEqual(check.name, "firewall (firewalld)")
+        self.assertEqual(check.status, diagnostics.STATUS_WARN)
+        self.assertIn("could not verify", check.message)
+
+    def test_firewalld_query_auth_failure_is_not_reported_closed(self):
+        # `--state` says running, but the port probe hits an auth error; that is
+        # "couldn't verify", not a definitive "port closed".
+        err = "Authorization failed."
+
+        def fake_run(args, timeout=3.0):
+            if "--state" in args:
+                return _completed("running")
+            return _completed("", returncode=1, stderr=err)
+
+        with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
+                mock.patch("diagnostics._run", side_effect=fake_run):
+            check = diagnostics._firewall_check()
+        self.assertEqual(check.status, diagnostics.STATUS_WARN)
+        self.assertIn("could not verify", check.message)
+        self.assertNotIn("closed", check.message)
+
     def test_query_timeout_is_handled(self):
         with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/sbin/ufw" if b == "ufw" else None), \
                 mock.patch("diagnostics._run", side_effect=subprocess.TimeoutExpired(cmd="ufw", timeout=3.0)):


### PR DESCRIPTION
Follow-up to #70, as you offered in review. =]

The `--doctor` firewalld check had two red tests in `tests/test_diagnostics.py`:

- `test_firewalld_running_without_port_warns`
- `test_returns_worst_case_across_front_ends`

**Root cause:** `_firewalld_check()` warned whenever firewalld was *running*, without ever checking whether the WFD RTSP port (`7236/tcp`) was actually open, and it read daemon state via `systemctl is-active`. The tests expect it to query firewalld directly and report OK when the port is already allowed.

**Fix:** query firewalld with `firewall-cmd --state` and `firewall-cmd --query-port=7236/tcp`:

- not running -> **OK** (port not blocked)
- running, port open -> **OK**
- running, port closed -> **WARN** (with the `--add-port` remediation hint)

This mirrors the existing `ufw` path, which only warns when the port is genuinely closed. The old code carried a comment worrying that probing could prompt for auth — that only applies to `--add-port`; `--query-port` is a read-only D-Bus getter and never prompts.

All 17 firewall/subnet tests pass (`python3 -m unittest tests.test_diagnostics`); full suite green (27 tests).