### PR TITLE
Avoid redundant firewalld authorization prompts

### DIFF
--- a/src/wfd.py
+++ b/src/wfd.py
@@ -2392,6 +2392,7 @@ def _firewalld_active() -> bool:
 
 
 _FIREWALL_AUTH_TIMEOUT = 60.0
+_FIREWALL_QUERY_TIMEOUT = 3.0
 
 _WFD_FIREWALL_ZONE = "nm-shared"
 
@@ -2414,6 +2415,34 @@ def _open_wfd_firewall_port(port: int) -> bool:
     """
     if not _firewalld_active():
         return False
+
+    try:
+        query = _run(
+            [
+                "firewall-cmd",
+                f"--zone={_WFD_FIREWALL_ZONE}",
+                f"--query-port={port}/tcp",
+            ],
+            timeout=_FIREWALL_QUERY_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _print_firewall_manual_hint(port, f"could not check existing rule: {exc}")
+        return False
+
+    # A real query result is the literal ``yes``/``no`` output. Authorization
+    # failures can use the same non-zero status as a closed port, so do not
+    # infer the result from the return code alone.
+    query_status = query.stdout.strip().lower()
+    query_output = (query.stdout + query.stderr).strip()
+    if query_status == "yes":
+        return False  # The user already had it open; leave it untouched.
+    if query_status != "no":
+        _print_firewall_manual_hint(
+            port,
+            query_output or "firewall-cmd could not verify the existing rule",
+        )
+        return False
+
     print(f"[FluxCast WFD] Opening firewalld port {port}/tcp ({_WFD_FIREWALL_ZONE} zone) "
           "for this session; approve the authorization prompt if one appears.")
     try:

--- a/tests/test_wfd.py
+++ b/tests/test_wfd.py
@@ -1,0 +1,101 @@
+import contextlib
+import io
+import os
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import wfd  # noqa: E402
+
+
+def _completed(stdout="", returncode=0, stderr=""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class FirewallPortTest(unittest.TestCase):
+    def test_existing_port_skips_privileged_add(self):
+        calls = []
+        port = wfd.WFD_RTSP_PORT
+
+        def fake_run(args, timeout=5.0):
+            calls.append((args, timeout))
+            return _completed("yes")
+
+        with (
+            mock.patch.object(wfd, "_firewalld_active", return_value=True),
+            mock.patch.object(wfd, "_run", side_effect=fake_run),
+        ):
+            opened = wfd._open_wfd_firewall_port(port)
+
+        self.assertFalse(opened)
+        self.assertEqual(len(calls), 1)
+        self.assertIn(f"--query-port={port}/tcp", calls[0][0])
+
+    def test_closed_port_is_opened_after_successful_query(self):
+        calls = []
+        port = wfd.WFD_RTSP_PORT
+
+        def fake_run(args, timeout=5.0):
+            calls.append((args, timeout))
+            if f"--query-port={port}/tcp" in args:
+                return _completed("no", returncode=1)
+            return _completed("success")
+
+        with (
+            mock.patch.object(wfd, "_firewalld_active", return_value=True),
+            mock.patch.object(wfd, "_run", side_effect=fake_run),
+        ):
+            opened = wfd._open_wfd_firewall_port(port)
+
+        self.assertTrue(opened)
+        self.assertIn(f"--query-port={port}/tcp", calls[0][0])
+        self.assertIn(f"--add-port={port}/tcp", calls[1][0])
+
+    def test_query_error_fails_closed_without_add(self):
+        port = wfd.WFD_RTSP_PORT
+        calls = []
+
+        def fake_run(args, timeout=5.0):
+            calls.append(args)
+            return _completed("", returncode=1, stderr="Authorization failed")
+
+        output = io.StringIO()
+        with (
+            mock.patch.object(wfd, "_firewalld_active", return_value=True),
+            mock.patch.object(wfd, "_run", side_effect=fake_run),
+            contextlib.redirect_stdout(output),
+        ):
+            opened = wfd._open_wfd_firewall_port(port)
+
+        self.assertFalse(opened)
+        self.assertEqual(len(calls), 1)
+        self.assertIn(f"--query-port={port}/tcp", calls[0])
+        self.assertIn("Authorization failed", output.getvalue())
+        self.assertIn("--wfd-no-firewall", output.getvalue())
+
+    def test_query_timeout_fails_closed_without_add(self):
+        calls = []
+        port = wfd.WFD_RTSP_PORT
+
+        def fake_run(args, timeout=5.0):
+            calls.append(args)
+            raise subprocess.TimeoutExpired(args, timeout)
+
+        with (
+            mock.patch.object(wfd, "_firewalld_active", return_value=True),
+            mock.patch.object(wfd, "_run", side_effect=fake_run),
+        ):
+            opened = wfd._open_wfd_firewall_port(port)
+
+        self.assertFalse(opened)
+        self.assertEqual(len(calls), 1)
+        self.assertIn(f"--query-port={port}/tcp", calls[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- query the `nm-shared` firewalld zone before requesting a privileged port add
- leave an already-open port untouched
- fail closed with the existing manual-firewall hint when the query cannot be verified
- add unit coverage for the open, closed, authorization-error, and timeout paths

Fixes #76

## Testing

- `PYTHONPATH=src python3 -m unittest discover -s tests -q` (33 tests)
- `python3 -m compileall -q src tests`

The query uses firewalld's normal `yes`/`no` exit/status pair; errors and timeouts do not fall through to `--add-port`.
