### PR TITLE
fix(wfd): show ffmpeg progress stats

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -36,6 +36,7 @@ Wi-Fi Display (Miracast) Options:
     --wfd-peer PEER          Peer selector: index, MAC, or name
     --wfd-dry-run            Print D-Bus call without activating connection
     --wfd-test-pattern       Stream generated test video instead of the desktop
+    --wfd-ffmpeg-stats       Show ffmpeg progress statistics for WFD streams
     --wfd-media-pipeline auto|ffmpeg|gst
                              RTP media sender (default: auto)
     --wfd-capture-backend auto|portal|wf-recorder|x11grab
@@ -133,6 +134,8 @@ def parse_args() -> argparse.Namespace:
                      help="Print WFD connection D-Bus call without activating it")
     wfd.add_argument("--wfd-test-pattern", action="store_true", dest="wfd_test_pattern",
                      help="For --protocol wfd, stream generated test video instead of the desktop")
+    wfd.add_argument("--wfd-ffmpeg-stats", action="store_true", dest="wfd_ffmpeg_stats",
+                     help="For --protocol wfd, show ffmpeg progress statistics")
     wfd.add_argument("--wfd-media-pipeline", default="auto",
                      choices=["auto", "ffmpeg", "gst"],
                      dest="wfd_media_pipeline",

--- a/src/wfd.py
+++ b/src/wfd.py
@@ -764,6 +764,13 @@ def _netdev_tx_bytes(interface: Optional[str]) -> Optional[int]:
     return None
 
 
+def _ffmpeg_sender_args() -> list[str]:
+    return [
+        "ffmpeg", "-hide_banner", "-y",
+        "-loglevel", "warning", "-stats",
+    ]
+
+
 class WFDMediaPipeline:
     def __init__(
         self,
@@ -887,8 +894,7 @@ class WFDMediaPipeline:
         gop = _calculate_gop(self.config)
         _tp_h = (_parse_resolution(resolution) or (1280, 720))[1]
         cmd = [
-            "ffmpeg", "-hide_banner", "-y",
-            "-loglevel", "warning",
+            *_ffmpeg_sender_args(),
             "-re",
             "-f", "lavfi",
             "-i", f"testsrc2=size={resolution}:rate={self.config.fps}",
@@ -1439,8 +1445,7 @@ class WFDMediaPipeline:
         ]
 
         ffmpeg_cmd = [
-            "ffmpeg", "-hide_banner", "-y",
-            "-loglevel", "warning",
+            *_ffmpeg_sender_args(),
             "-fflags", "+genpts",
             "-thread_queue_size", "1024",
             "-f", "nut",
@@ -1543,8 +1548,7 @@ class WFDMediaPipeline:
 
         display = os.environ.get("DISPLAY", monitor.display or ":0")
         ffmpeg_cmd = [
-            "ffmpeg", "-hide_banner", "-y",
-            "-loglevel", "warning",
+            *_ffmpeg_sender_args(),
             "-thread_queue_size", "1024",
             "-f", "x11grab",
             "-framerate", str(self.config.fps),

--- a/src/wfd.py
+++ b/src/wfd.py
@@ -155,6 +155,7 @@ class WFDMediaConfig:
     audio_device: Optional[str] = None
     no_audio: bool = False
     test_pattern: bool = False
+    ffmpeg_stats: bool = False
     source_port: int = 19002
     media_pipeline: str = "auto"
     latency_log_path: Optional[str] = None
@@ -764,11 +765,14 @@ def _netdev_tx_bytes(interface: Optional[str]) -> Optional[int]:
     return None
 
 
-def _ffmpeg_sender_args() -> list[str]:
-    return [
+def _ffmpeg_sender_args(show_stats: bool = False) -> list[str]:
+    args = [
         "ffmpeg", "-hide_banner", "-y",
-        "-loglevel", "warning", "-stats",
+        "-loglevel", "warning",
     ]
+    if show_stats:
+        args.append("-stats")
+    return args
 
 
 class WFDMediaPipeline:
@@ -894,7 +898,7 @@ class WFDMediaPipeline:
         gop = _calculate_gop(self.config)
         _tp_h = (_parse_resolution(resolution) or (1280, 720))[1]
         cmd = [
-            *_ffmpeg_sender_args(),
+            *_ffmpeg_sender_args(self.config.ffmpeg_stats),
             "-re",
             "-f", "lavfi",
             "-i", f"testsrc2=size={resolution}:rate={self.config.fps}",
@@ -1445,7 +1449,7 @@ class WFDMediaPipeline:
         ]
 
         ffmpeg_cmd = [
-            *_ffmpeg_sender_args(),
+            *_ffmpeg_sender_args(self.config.ffmpeg_stats),
             "-fflags", "+genpts",
             "-thread_queue_size", "1024",
             "-f", "nut",
@@ -1548,7 +1552,7 @@ class WFDMediaPipeline:
 
         display = os.environ.get("DISPLAY", monitor.display or ":0")
         ffmpeg_cmd = [
-            *_ffmpeg_sender_args(),
+            *_ffmpeg_sender_args(self.config.ffmpeg_stats),
             "-thread_queue_size", "1024",
             "-f", "x11grab",
             "-framerate", str(self.config.fps),
@@ -3539,6 +3543,7 @@ def start_experimental_backend(args) -> None:
         audio_device=getattr(args, "wfd_audio_device", None),
         no_audio=no_audio,
         test_pattern=getattr(args, "wfd_test_pattern", False),
+        ffmpeg_stats=getattr(args, "wfd_ffmpeg_stats", False),
         source_port=getattr(args, "wfd_rtp_source_port", 19002),
         media_pipeline=getattr(args, "wfd_media_pipeline", "auto"),
         latency_log_path=getattr(args, "wfd_latency_log", None),

--- a/tests/test_wfd.py
+++ b/tests/test_wfd.py
@@ -18,13 +18,18 @@ def _completed(stdout="", returncode=0, stderr=""):
 
 
 class FfmpegProgressArgsTest(unittest.TestCase):
-    def test_warning_loglevel_keeps_progress_stats_visible(self):
+    def test_progress_stats_are_disabled_by_default(self):
         args = wfd._ffmpeg_sender_args()
 
         self.assertEqual(
             args,
-            ["ffmpeg", "-hide_banner", "-y", "-loglevel", "warning", "-stats"],
+            ["ffmpeg", "-hide_banner", "-y", "-loglevel", "warning"],
         )
+
+    def test_progress_stats_can_be_enabled(self):
+        args = wfd._ffmpeg_sender_args(show_stats=True)
+
+        self.assertIn("-stats", args)
 
 
 class FirewallPortTest(unittest.TestCase):

--- a/tests/test_wfd.py
+++ b/tests/test_wfd.py
@@ -17,6 +17,16 @@ def _completed(stdout="", returncode=0, stderr=""):
     )
 
 
+class FfmpegProgressArgsTest(unittest.TestCase):
+    def test_warning_loglevel_keeps_progress_stats_visible(self):
+        args = wfd._ffmpeg_sender_args()
+
+        self.assertEqual(
+            args,
+            ["ffmpeg", "-hide_banner", "-y", "-loglevel", "warning", "-stats"],
+        )
+
+
 class FirewallPortTest(unittest.TestCase):
     def test_existing_port_skips_privileged_add(self):
         calls = []


### PR DESCRIPTION
## Summary

- I enabled ffmpeg's progress line while keeping the existing warning log level.
- I applied the shared sender arguments to test-pattern, wf-recorder, and x11grab WFD streams.
- I added a regression test for the progress arguments.

## Validation

- `python3 -m unittest tests.test_wfd.FfmpegProgressArgsTest -v`
- `python3 -m unittest discover -s tests` (46 tests)
- `python3 -m compileall -q src tests`
- `git diff --check origin/dev...HEAD`

Fixes https://github.com/IlyaP358/fluxcast/issues/81
