### PR TITLE
Skip firewall diagnostics with --wfd-no-firewall

### DIFF
--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -662,7 +662,12 @@ def _python_check() -> Check:
     )
 
 
-def run_diagnostics() -> DiagnosticReport:
+def run_diagnostics(skip_firewall: bool = False) -> DiagnosticReport:
+    firewall_check = (
+        Check("firewall", STATUS_SKIP, "disabled by --wfd-no-firewall")
+        if skip_firewall
+        else _firewall_check()
+    )
     checks = [
         _python_check(),
         _command_check("ffmpeg", "video/audio transcoding", required=True),
@@ -702,7 +707,7 @@ def run_diagnostics() -> DiagnosticReport:
         _iw_p2p_check(),
         _supplicant_capability_check(),
         _supplicant_wfd_check(),
-        _firewall_check(),
+        firewall_check,
     ]
 
     by_name = {check.name: check for check in checks}

--- a/src/main.py
+++ b/src/main.py
@@ -244,7 +244,7 @@ def main() -> None:
 
     if args.doctor or args.doctor_json:
         from diagnostics import print_report, run_diagnostics
-        report = run_diagnostics()
+        report = run_diagnostics(skip_firewall=getattr(args, "wfd_no_firewall", False))
         if args.doctor_json:
             print(report.to_json())
         else:

--- a/src/wfd.py
+++ b/src/wfd.py
@@ -3490,7 +3490,7 @@ def _active_rtsp_probe(
 
 
 def start_experimental_backend(args) -> None:
-    report = run_diagnostics()
+    report = run_diagnostics(skip_firewall=getattr(args, "wfd_no_firewall", False))
     print_report(report)
     print()
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -15,6 +15,14 @@ def _completed(stdout="", returncode=0, stderr=""):
 
 
 class FirewallCheckTest(unittest.TestCase):
+    def test_run_diagnostics_skips_firewall_probe_when_requested(self):
+        with mock.patch("diagnostics._firewall_check") as firewall_check:
+            report = diagnostics.run_diagnostics(skip_firewall=True)
+
+        firewall_check.assert_not_called()
+        firewall = next(check for check in report.checks if check.name == "firewall")
+        self.assertEqual(firewall.status, diagnostics.STATUS_SKIP)
+
     def test_skips_when_no_firewall_tool(self):
         with mock.patch("diagnostics.shutil.which", return_value=None):
             check = diagnostics._firewall_check()

--- a/tests/test_wfd.py
+++ b/tests/test_wfd.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -110,6 +111,21 @@ class FirewallPortTest(unittest.TestCase):
         self.assertFalse(opened)
         self.assertEqual(len(calls), 1)
         self.assertIn(f"--query-port={port}/tcp", calls[0])
+
+
+class StartBackendDiagnosticsTest(unittest.TestCase):
+    def test_no_firewall_flag_is_forwarded_to_diagnostics(self):
+        args = SimpleNamespace(wfd_no_firewall=True)
+        report = SimpleNamespace(wfd_candidate=False)
+
+        with (
+            mock.patch.object(wfd, "run_diagnostics", return_value=report) as run,
+            mock.patch.object(wfd, "print_report"),
+            self.assertRaises(wfd.WFDNotReady),
+        ):
+            wfd.start_experimental_backend(args)
+
+        run.assert_called_once_with(skip_firewall=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Honor `--wfd-no-firewall` during the startup doctor phase by forwarding the flag to diagnostics and returning a skipped firewall check without invoking `ufw` or `firewall-cmd`.

This avoids the Polkit prompt and timeout before monitor selection while keeping the rest of the readiness report unchanged.

## Verification

- `python3 -m unittest discover -s tests` (49 tests)
- `python3 -m compileall -q src`

Fixes #82
