### PR TITLE
Fix P2P neighbor selection for active probes

### DIFF
--- a/src/wfd/p2p/addressing.py
+++ b/src/wfd/p2p/addressing.py
@@ -6,6 +6,10 @@ from typing import Optional
 from ..proc import _run
 
 
+def _is_p2p_group_iface(iface: str) -> bool:
+    return iface.startswith("p2p-") and not iface.startswith("p2p-dev-")
+
+
 def _get_peer_ip_from_arp(peer_mac: str) -> Optional[str]:
     """Return the IP for peer_mac from the kernel ARP/neighbour table."""
     if not shutil.which("ip"):
@@ -16,13 +20,19 @@ def _get_peer_ip_from_arp(peer_mac: str) -> Optional[str]:
             return None
         mac = peer_mac.lower().replace("-", ":")
         for line in result.stdout.splitlines():
-            if mac in line.lower():
-                parts = line.split()
-                if parts and re.fullmatch(r"\d+\.\d+\.\d+\.\d+", parts[0]):
+            parts = line.split()
+            if len(parts) >= 3 and parts[1] == "dev":
+                iface = parts[2]
+                if (
+                    mac in line.lower()
+                    and _is_p2p_group_iface(iface)
+                    and re.fullmatch(r"\d+\.\d+\.\d+\.\d+", parts[0])
+                ):
                     return parts[0]
     except Exception:
         pass
     return None
+
 
 def _get_peer_ip_from_p2p_iface() -> Optional[str]:
     """Fallback: find TV IP from ARP on any active P2P group interface.
@@ -40,12 +50,13 @@ def _get_peer_ip_from_p2p_iface() -> Optional[str]:
             parts = line.split()
             if len(parts) >= 3 and parts[1] == "dev":
                 iface = parts[2]
-                if iface.startswith("p2p-") and not iface.startswith("p2p-dev-"):
+                if _is_p2p_group_iface(iface):
                     if re.fullmatch(r"\d+\.\d+\.\d+\.\d+", parts[0]):
                         return parts[0]
     except Exception:
         pass
     return None
+
 
 def _wait_for_peer_ip(peer_mac: str, timeout: float = 12.0) -> Optional[str]:
     """Poll ARP until the peer's IP appears (DHCP may take a few seconds)."""

--- a/tests/test_addressing.py
+++ b/tests/test_addressing.py
@@ -1,0 +1,75 @@
+import os
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from wfd.p2p import addressing  # noqa: E402
+
+
+PEER_MAC = "00:51:ed:35:0f:ae"
+P2P_IP = "10.42.0.182"
+
+
+def _completed(stdout="", returncode=0, stderr=""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class PeerIpAddressingTest(unittest.TestCase):
+    def test_mac_lookup_ignores_infrastructure_interface(self):
+        neighbours = "\n".join(
+            [
+                f"192.168.178.54 dev wlan0 lladdr {PEER_MAC} REACHABLE",
+                f"{P2P_IP} dev p2p-wlan0-3 lladdr {PEER_MAC} REACHABLE",
+            ]
+        )
+
+        with (
+            mock.patch.object(addressing.shutil, "which", return_value="/usr/bin/ip"),
+            mock.patch.object(addressing, "_run", return_value=_completed(neighbours)),
+        ):
+            peer_ip = addressing._get_peer_ip_from_arp(PEER_MAC)
+
+        self.assertEqual(peer_ip, P2P_IP)
+
+    def test_mac_lookup_excludes_p2p_device_interface(self):
+        neighbours = (
+            f"192.168.49.1 dev p2p-dev-wlan0 lladdr {PEER_MAC} REACHABLE"
+        )
+
+        with (
+            mock.patch.object(addressing.shutil, "which", return_value="/usr/bin/ip"),
+            mock.patch.object(addressing, "_run", return_value=_completed(neighbours)),
+        ):
+            peer_ip = addressing._get_peer_ip_from_arp(PEER_MAC)
+
+        self.assertIsNone(peer_ip)
+
+    def test_randomized_mac_falls_back_to_p2p_group_interface(self):
+        randomized_mac = "7a:11:22:33:44:55"
+        neighbours = "\n".join(
+            [
+                f"192.168.178.54 dev wlan0 lladdr {PEER_MAC} REACHABLE",
+                f"{P2P_IP} dev p2p-wlan0-3 lladdr {randomized_mac} REACHABLE",
+            ]
+        )
+
+        with (
+            mock.patch.object(addressing.shutil, "which", return_value="/usr/bin/ip"),
+            mock.patch.object(addressing, "_run", return_value=_completed(neighbours)),
+        ):
+            direct_ip = addressing._get_peer_ip_from_arp(PEER_MAC)
+            fallback_ip = addressing._get_peer_ip_from_p2p_iface()
+            waited_ip = addressing._wait_for_peer_ip(PEER_MAC, timeout=0.1)
+
+        self.assertIsNone(direct_ip)
+        self.assertEqual(fallback_ip, P2P_IP)
+        self.assertEqual(waited_ip, P2P_IP)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- restrict MAC-based neighbour lookup to `p2p-*` group interfaces
- exclude `p2p-dev-*` and infrastructure interfaces from active probe targets
- preserve the interface-only fallback for TVs that randomize their MAC during group setup

The regression tests mock `ip neigh` output for a duplicate MAC across home/P2P interfaces, a `p2p-dev-*` entry, and the randomized-MAC fallback.

## Testing
- `PYSTRAY_BACKEND=dummy python -m unittest discover -s tests -v` (82 tests)
- `python -m compileall -q src tests`
- `git diff --check`

Fixes #85
