### PR TITLE
Validate wf-recorder before starting WFD capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,10 @@ Note: on KDE/GNOME Wayland, WFD auto backend now prefers `portal` first.
 
 Note: on **firewalld** systems, FluxCast opens the WFD RTSP port (`7236/tcp`) for the duration of a session and closes it on exit (no-op without firewalld; disable with `--wfd-no-firewall`). See [DOCUMENTATION.md](documentation/DOCUMENTATION.md) -> "WFD and firewalld".
 
-If you use **ufw**, open the WFD RTSP and discovery ports before connecting:
+If you use **ufw**, open the WFD RTSP port before connecting:
 
 ```bash
 sudo ufw allow 7236/tcp
-sudo ufw allow 5353/udp
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,13 @@ Note: on KDE/GNOME Wayland, WFD auto backend now prefers `portal` first.
 
 Note: on **firewalld** systems, FluxCast opens the WFD RTSP port (`7236/tcp`) for the duration of a session and closes it on exit (no-op without firewalld; disable with `--wfd-no-firewall`). See [DOCUMENTATION.md](documentation/DOCUMENTATION.md) -> "WFD and firewalld".
 
+If you use **ufw**, open the WFD RTSP and discovery ports before connecting:
+
+```bash
+sudo ufw allow 7236/tcp
+sudo ufw allow 5353/udp
+```
+
 
 ## Documentation
 

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -262,7 +262,6 @@ the port while a session is active and closes it on exit:
 
   ```bash
   sudo ufw allow 7236/tcp
-  sudo ufw allow 5353/udp
   ```
 
 Pass `--wfd-no-firewall` to skip this entirely and manage the firewall yourself.

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -258,7 +258,12 @@ the port while a session is active and closes it on exit:
   firewalld reload or reboot, and is removed automatically when FluxCast exits.
 - A port you already opened yourself is left untouched.
 - Other firewalls (`nftables`, `iptables`, `ufw`) are not modified — open the
-  RTSP port manually there, e.g. `sudo ufw allow 7236/tcp`.
+  WFD ports manually there. For ufw:
+
+  ```bash
+  sudo ufw allow 7236/tcp
+  sudo ufw allow 5353/udp
+  ```
 
 Pass `--wfd-no-firewall` to skip this entirely and manage the firewall yourself.
 

--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -9,6 +9,8 @@ import subprocess
 from dataclasses import asdict, dataclass
 from typing import Optional
 
+from wfd.wf_recorder import find_wf_recorder
+
 
 STATUS_OK = "ok"
 STATUS_WARN = "warn"
@@ -80,6 +82,22 @@ def _command_check(
 
     status = STATUS_FAIL if required else STATUS_WARN
     return Check(binary, status, purpose, "not found in PATH")
+
+
+def _wf_recorder_check() -> Check:
+    path = shutil.which("wf-recorder")
+    if not path:
+        return Check(
+            "wf-recorder", STATUS_WARN, "Wayland/wlroots screen capture",
+            "not found in PATH; install wf-recorder",
+        )
+    if find_wf_recorder():
+        return Check("wf-recorder", STATUS_OK, "Wayland/wlroots screen capture", path)
+    return Check(
+        "wf-recorder", STATUS_WARN,
+        "wf-recorder was found but could not be executed",
+        "the AppImage wrapper needs the system wf-recorder package; install wf-recorder",
+    )
 
 
 def _gst_element_check(element: str, purpose: str, install_hint: str) -> Check:
@@ -237,7 +255,7 @@ def _portal_process_check() -> Check:
 def _display_capture_check() -> Check:
     wayland = os.environ.get("WAYLAND_DISPLAY")
     x11 = os.environ.get("DISPLAY")
-    wf_recorder = _find_binary("wf-recorder")
+    wf_recorder = find_wf_recorder()
     xrandr = shutil.which("xrandr")
     portal = _find_binary(
         "xdg-desktop-portal",
@@ -671,7 +689,7 @@ def run_diagnostics(skip_firewall: bool = False) -> DiagnosticReport:
     checks = [
         _python_check(),
         _command_check("ffmpeg", "video/audio transcoding", required=True),
-        _command_check("wf-recorder", "Wayland/wlroots screen capture"),
+        _wf_recorder_check(),
         _portal_process_check(),
         _command_check("pactl", "PulseAudio/PipeWire-Pulse audio monitor detection"),
         _command_check("xrandr", "X11 monitor detection fallback"),

--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -9,8 +9,6 @@ import subprocess
 from dataclasses import asdict, dataclass
 from typing import Optional
 
-from wfd.wf_recorder import find_wf_recorder
-
 
 STATUS_OK = "ok"
 STATUS_WARN = "warn"
@@ -85,6 +83,9 @@ def _command_check(
 
 
 def _wf_recorder_check() -> Check:
+    # Deferred: wfd/__init__.py imports diagnostics; a top-level import cycles.
+    from wfd.wf_recorder import find_wf_recorder
+
     path = shutil.which("wf-recorder")
     if not path:
         return Check(
@@ -253,6 +254,9 @@ def _portal_process_check() -> Check:
 
 
 def _display_capture_check() -> Check:
+    # Deferred: wfd/__init__.py imports diagnostics; a top-level import cycles.
+    from wfd.wf_recorder import find_wf_recorder
+
     wayland = os.environ.get("WAYLAND_DISPLAY")
     x11 = os.environ.get("DISPLAY")
     wf_recorder = find_wf_recorder()

--- a/src/wfd/media/wlroots.py
+++ b/src/wfd/media/wlroots.py
@@ -3,6 +3,7 @@ import subprocess
 import time
 
 from ..config import WFDNotReady
+from ..wf_recorder import find_wf_recorder
 from ..encoding import (
     _bitrate_to_kbits, _calculate_gop, _kbits_to_bitrate_text, _letterbox_vf,
     _parse_resolution, _quality_floor_kbits, _vbv_bufsize,
@@ -14,7 +15,8 @@ from ..net import _ffmpeg_sender_args
 
 class WlrootsMixin:
     def _start_desktop_wf_recorder(self) -> None:
-        if not shutil.which("wf-recorder"):
+        wf_recorder = find_wf_recorder()
+        if not wf_recorder:
             raise WFDNotReady("wf-recorder is required for WFD desktop streaming.")
 
         monitor = self.config.monitor
@@ -36,7 +38,7 @@ class WlrootsMixin:
             )
 
         wf_cmd = [
-            "wf-recorder",
+            wf_recorder,
             "-y",
             "-D",
             "-r", str(self.config.fps),

--- a/src/wfd/wf_recorder.py
+++ b/src/wfd/wf_recorder.py
@@ -1,0 +1,19 @@
+"""Discovery and validation for the wlroots screen recorder."""
+
+import shutil
+import subprocess
+from typing import Optional
+
+
+def find_wf_recorder() -> Optional[str]:
+    """Return a usable wf-recorder path, or None if a wrapper cannot run it."""
+    path = shutil.which("wf-recorder")
+    if not path:
+        return None
+    try:
+        result = subprocess.run(
+            [path, "--version"], capture_output=True, text=True, timeout=3.0
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return path if result.returncode == 0 else None

--- a/src/wfd/wf_recorder.py
+++ b/src/wfd/wf_recorder.py
@@ -4,6 +4,9 @@ import shutil
 import subprocess
 from typing import Optional
 
+# AppImage wrappers exit 127 when the host wf-recorder binary is missing.
+_WRAPPER_MISSING_BINARY = 127
+
 
 def find_wf_recorder() -> Optional[str]:
     """Return a usable wf-recorder path, or None if a wrapper cannot run it."""
@@ -16,4 +19,8 @@ def find_wf_recorder() -> Optional[str]:
         )
     except (OSError, subprocess.TimeoutExpired):
         return None
-    return path if result.returncode == 0 else None
+    # Reject only the AppImage "command not found" exit; other non-zero codes
+    # (e.g. older builds without --version) must not disable a working binary.
+    if result.returncode == _WRAPPER_MISSING_BINARY:
+        return None
+    return path

--- a/tests/test_wf_recorder.py
+++ b/tests/test_wf_recorder.py
@@ -26,6 +26,13 @@ class FindWfRecorderTest(unittest.TestCase):
         run.return_value = subprocess.CompletedProcess([], 0, "wf-recorder 0.6.0", "")
         self.assertEqual(find_wf_recorder(), "/usr/bin/wf-recorder")
 
+    @mock.patch("wfd.wf_recorder.subprocess.run")
+    @mock.patch("wfd.wf_recorder.shutil.which", return_value="/usr/bin/wf-recorder")
+    def test_accepts_recorder_without_version_flag(self, _which, run):
+        # Older builds may not support --version; only exit 127 is a hard reject.
+        run.return_value = subprocess.CompletedProcess([], 1, "", "unknown option")
+        self.assertEqual(find_wf_recorder(), "/usr/bin/wf-recorder")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wf_recorder.py
+++ b/tests/test_wf_recorder.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from wfd.wf_recorder import find_wf_recorder  # noqa: E402
+
+
+class FindWfRecorderTest(unittest.TestCase):
+    @mock.patch("wfd.wf_recorder.shutil.which", return_value=None)
+    def test_missing_recorder(self, _which):
+        self.assertIsNone(find_wf_recorder())
+
+    @mock.patch("wfd.wf_recorder.subprocess.run")
+    @mock.patch("wfd.wf_recorder.shutil.which", return_value="/app/usr/bin/wf-recorder")
+    def test_rejects_wrapper_when_system_recorder_is_missing(self, _which, run):
+        run.return_value = subprocess.CompletedProcess([], 127, "", "not found")
+        self.assertIsNone(find_wf_recorder())
+
+    @mock.patch("wfd.wf_recorder.subprocess.run")
+    @mock.patch("wfd.wf_recorder.shutil.which", return_value="/usr/bin/wf-recorder")
+    def test_accepts_working_recorder(self, _which, run):
+        run.return_value = subprocess.CompletedProcess([], 0, "wf-recorder 0.6.0", "")
+        self.assertEqual(find_wf_recorder(), "/usr/bin/wf-recorder")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Validate `wf-recorder --version` instead of treating an executable wrapper as sufficient.
- Use the same validation before starting the WFD wlroots capture pipeline.
- Add tests for a missing recorder, a failing AppImage-style wrapper, and a working recorder.
- Document the UFW rules needed for WFD RTSP and discovery:
  - `7236/tcp`
  - `5353/udp`

Fixes #96
Related to #98

## Verification

- `python -m unittest tests.test_wf_recorder tests.test_diagnostics`
- `python -m py_compile src/wfd/wf_recorder.py src/wfd/media/wlroots.py src/diagnostics.py`
- `git diff --check`

The complete local suite currently has one pre-existing environment failure because the optional `PIL` module is not installed for `tests/test_tray_config.py`.
