### PR TITLE
Fix wpa_supplicant D-Bus policy over-grant 

### DIFF
--- a/appimage/fluxcast-setup.sh
+++ b/appimage/fluxcast-setup.sh
@@ -6,11 +6,18 @@ DBUS_CONF_NAME="zz-dev.fluxcast.wpa-supplicant.conf"
 DBUS_CONF_DEST="/usr/share/dbus-1/system.d/${DBUS_CONF_NAME}"
 DBUS_CONF_SRC="${APPDIR}/meta/${DBUS_CONF_NAME}"
 
-[ -f "${DBUS_CONF_DEST}" ] && exit 0   # already installed, nothing to do
 [ -f "${DBUS_CONF_SRC}" ]  || exit 0   # config missing from AppDir, skip
+# Refresh when missing or content changed (e.g. insecure default-context grant).
+if [ -f "${DBUS_CONF_DEST}" ] && cmp -s "${DBUS_CONF_SRC}" "${DBUS_CONF_DEST}"; then
+    exit 0
+fi
 
 echo ""
-echo "[FluxCast] First-time setup: installing DBus policy for Wi-Fi Direct..."
+if [ -f "${DBUS_CONF_DEST}" ]; then
+    echo "[FluxCast] Updating DBus policy for Wi-Fi Direct..."
+else
+    echo "[FluxCast] First-time setup: installing DBus policy for Wi-Fi Direct..."
+fi
 
 # FUSE mounts are not accessible by root. Copy to /tmp first so sudo can read it.
 TMP_CONF="$(mktemp /tmp/fluxcast-dbus-XXXXXX.conf)"

--- a/meta/zz-dev.fluxcast.wpa-supplicant.conf
+++ b/meta/zz-dev.fluxcast.wpa-supplicant.conf
@@ -2,7 +2,22 @@
  "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
-  <policy context="default">
+  <!--
+    FluxCast needs Properties.Set for P2PDeviceConfig (device name + GO intent).
+    D-Bus cannot limit that grant to a single property, so scope who may send it:
+    wheel on Arch/Fedora, sudo on Debian/Ubuntu. Do not use context="default" —
+    that would override wpa_supplicant's intentional deny for every local account.
+  -->
+  <policy group="wheel">
+    <allow send_destination="fi.w1.wpa_supplicant1"
+           send_interface="org.freedesktop.DBus.Properties"
+           send_member="Get"/>
+    <allow send_destination="fi.w1.wpa_supplicant1"
+           send_interface="org.freedesktop.DBus.Properties"
+           send_member="Set"/>
+    <allow receive_sender="fi.w1.wpa_supplicant1"/>
+  </policy>
+  <policy group="sudo">
     <allow send_destination="fi.w1.wpa_supplicant1"
            send_interface="org.freedesktop.DBus.Properties"
            send_member="Get"/>

--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -1,6 +1,7 @@
 import json
 import importlib.util
 import ipaddress
+import grp
 import os
 import platform
 import re
@@ -8,6 +9,11 @@ import shutil
 import subprocess
 from dataclasses import asdict, dataclass
 from typing import Optional
+
+# Admin groups that may receive the FluxCast wpa_supplicant Properties.Set grant.
+# wheel: Arch/Fedora; sudo: Debian/Ubuntu. Desktop users who can already elevate
+# are typically in one of these.
+WPA_DBUS_ADMIN_GROUPS = ("wheel", "sudo")
 
 
 STATUS_OK = "ok"
@@ -506,6 +512,43 @@ def _subnet_conflict_check() -> Check:
     )
 
 
+def _user_admin_groups() -> list[str]:
+    """Return which of WPA_DBUS_ADMIN_GROUPS the current user belongs to."""
+    gids = set(os.getgroups())
+    gids.add(os.getgid())
+    names: set[str] = set()
+    for gid in gids:
+        try:
+            names.add(grp.getgrgid(gid).gr_name)
+        except KeyError:
+            continue
+    return [name for name in WPA_DBUS_ADMIN_GROUPS if name in names]
+
+
+def _wpa_dbus_admin_group_check() -> Check:
+    """Warn when the user cannot use the scoped wpa_supplicant D-Bus policy.
+
+    FluxCast's system.d policy grants Properties.Set only to wheel/sudo so
+    unprivileged accounts cannot write supplicant properties. Losing that
+    grant quietly breaks LG sinks (GO intent) and device naming.
+    """
+    membership = _user_admin_groups()
+    if membership:
+        joined = "/".join(membership)
+        return Check(
+            "wpa D-Bus group",
+            STATUS_OK,
+            f"member of {joined}; can set P2PDeviceConfig",
+            "",
+        )
+    return Check(
+        "wpa D-Bus group",
+        STATUS_WARN,
+        "not in an admin group; device name and GO intent Set may fail",
+        f"add your user to {' or '.join(WPA_DBUS_ADMIN_GROUPS)} (or re-login after usermod)",
+    )
+
+
 def _supplicant_capability_check() -> Check:
     if not shutil.which("gdbus"):
         return Check("wpa_supplicant P2P", STATUS_WARN, "gdbus was not found", "cannot query system D-Bus")
@@ -729,6 +772,7 @@ def run_diagnostics(skip_firewall: bool = False) -> DiagnosticReport:
         _iw_p2p_check(),
         _supplicant_capability_check(),
         _supplicant_wfd_check(),
+        _wpa_dbus_admin_group_check(),
         firewall_check,
     ]
 

--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -525,28 +525,56 @@ def _user_admin_groups() -> list[str]:
     return [name for name in WPA_DBUS_ADMIN_GROUPS if name in names]
 
 
-def _wpa_dbus_admin_group_check() -> Check:
-    """Warn when the user cannot use the scoped wpa_supplicant D-Bus policy.
+def _wpa_dbus_set_check() -> Check:
+    """Probe whether Properties.Set on wpa_supplicant is permitted for this user.
 
     FluxCast's system.d policy grants Properties.Set only to wheel/sudo so
-    unprivileged accounts cannot write supplicant properties. Losing that
-    grant quietly breaks LG sinks (GO intent) and device naming.
+    unprivileged accounts cannot write supplicant properties. A Set on a
+    non-existent property is authoritative: AccessDenied means the bus policy
+    blocks the call; InvalidArgs / No such property means the grant is live.
     """
-    membership = _user_admin_groups()
-    if membership:
-        joined = "/".join(membership)
+    name = "wpa D-Bus Set"
+    if not shutil.which("gdbus"):
+        return Check(name, STATUS_WARN, "gdbus was not found", "cannot probe wpa_supplicant D-Bus policy")
+
+    args = [
+        "gdbus", "call", "--system",
+        "--dest", "fi.w1.wpa_supplicant1",
+        "--object-path", "/fi/w1/wpa_supplicant1",
+        "--method", "org.freedesktop.DBus.Properties.Set",
+        "fi.w1.wpa_supplicant1",
+        "FluxCastDoctorProbe",
+        "<'probe'>",
+    ]
+    try:
+        result = _run(args, timeout=3.0)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return Check(name, STATUS_WARN, "could not probe wpa_supplicant D-Bus policy", str(exc))
+
+    text = (result.stdout + result.stderr).strip()
+    if "AccessDenied" in text:
+        membership = _user_admin_groups()
+        if membership:
+            detail = (
+                "Properties.Set is blocked despite admin group membership; "
+                "install meta/zz-dev.fluxcast.wpa-supplicant.conf and reload dbus"
+            )
+        else:
+            detail = (
+                f"add your user to {' or '.join(WPA_DBUS_ADMIN_GROUPS)} "
+                "(or re-login after usermod), then install the FluxCast D-Bus policy"
+            )
         return Check(
-            "wpa D-Bus group",
-            STATUS_OK,
-            f"member of {joined}; can set P2PDeviceConfig",
-            "",
+            name,
+            STATUS_WARN,
+            "Properties.Set on wpa_supplicant is denied",
+            detail,
         )
-    return Check(
-        "wpa D-Bus group",
-        STATUS_WARN,
-        "not in an admin group; device name and GO intent Set may fail",
-        f"add your user to {' or '.join(WPA_DBUS_ADMIN_GROUPS)} (or re-login after usermod)",
-    )
+    if "No such property" in text or "InvalidArgs" in text:
+        return Check(name, STATUS_OK, "Properties.Set on wpa_supplicant is permitted", text)
+    if result.returncode != 0:
+        return Check(name, STATUS_WARN, "wpa_supplicant D-Bus probe failed", text)
+    return Check(name, STATUS_OK, "Properties.Set on wpa_supplicant is permitted", text)
 
 
 def _supplicant_capability_check() -> Check:
@@ -772,7 +800,7 @@ def run_diagnostics(skip_firewall: bool = False) -> DiagnosticReport:
         _iw_p2p_check(),
         _supplicant_capability_check(),
         _supplicant_wfd_check(),
-        _wpa_dbus_admin_group_check(),
+        _wpa_dbus_set_check(),
         firewall_check,
     ]
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -132,6 +132,55 @@ class FirewallCheckTest(unittest.TestCase):
         self.assertEqual(check.status, diagnostics.STATUS_WARN)
 
 
+class WpaDbusAdminGroupCheckTest(unittest.TestCase):
+    def test_member_of_wheel_is_ok(self):
+        with mock.patch("diagnostics._user_admin_groups", return_value=["wheel"]):
+            check = diagnostics._wpa_dbus_admin_group_check()
+        self.assertEqual(check.name, "wpa D-Bus group")
+        self.assertEqual(check.status, diagnostics.STATUS_OK)
+        self.assertIn("wheel", check.message)
+
+    def test_member_of_sudo_is_ok(self):
+        with mock.patch("diagnostics._user_admin_groups", return_value=["sudo"]):
+            check = diagnostics._wpa_dbus_admin_group_check()
+        self.assertEqual(check.status, diagnostics.STATUS_OK)
+        self.assertIn("sudo", check.message)
+
+    def test_missing_admin_group_warns(self):
+        with mock.patch("diagnostics._user_admin_groups", return_value=[]):
+            check = diagnostics._wpa_dbus_admin_group_check()
+        self.assertEqual(check.status, diagnostics.STATUS_WARN)
+        self.assertIn("wheel", check.detail)
+        self.assertIn("sudo", check.detail)
+
+    def test_run_diagnostics_includes_admin_group_check(self):
+        with mock.patch("diagnostics._wpa_dbus_admin_group_check") as probe, \
+                mock.patch("diagnostics._firewall_check"):
+            probe.return_value = diagnostics.Check(
+                "wpa D-Bus group", diagnostics.STATUS_OK, "member of wheel",
+            )
+            report = diagnostics.run_diagnostics(skip_firewall=True)
+        probe.assert_called_once()
+        names = [check.name for check in report.checks]
+        self.assertIn("wpa D-Bus group", names)
+
+
+class WpaDbusPolicyConfTest(unittest.TestCase):
+    def test_shipped_policy_is_scoped_to_admin_groups(self):
+        conf_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "meta",
+            "zz-dev.fluxcast.wpa-supplicant.conf",
+        )
+        with open(conf_path, encoding="utf-8") as fh:
+            text = fh.read()
+        self.assertNotRegex(text, r'<policy\s+context="default"')
+        self.assertIn('group="wheel"', text)
+        self.assertIn('group="sudo"', text)
+        self.assertIn('send_member="Set"', text)
+
+
 class SubnetConflictCheckTest(unittest.TestCase):
     def test_skips_when_ip_missing(self):
         with mock.patch("diagnostics.shutil.which", return_value=None):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -132,37 +132,70 @@ class FirewallCheckTest(unittest.TestCase):
         self.assertEqual(check.status, diagnostics.STATUS_WARN)
 
 
-class WpaDbusAdminGroupCheckTest(unittest.TestCase):
-    def test_member_of_wheel_is_ok(self):
-        with mock.patch("diagnostics._user_admin_groups", return_value=["wheel"]):
-            check = diagnostics._wpa_dbus_admin_group_check()
-        self.assertEqual(check.name, "wpa D-Bus group")
+class WpaDbusSetCheckTest(unittest.TestCase):
+    def test_permitted_set_is_ok(self):
+        with mock.patch("diagnostics.shutil.which", return_value="/usr/bin/gdbus"), \
+                mock.patch(
+                    "diagnostics._run",
+                    return_value=_completed(
+                        "Error: GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: "
+                        "No such property",
+                        returncode=1,
+                    ),
+                ):
+            check = diagnostics._wpa_dbus_set_check()
+        self.assertEqual(check.name, "wpa D-Bus Set")
         self.assertEqual(check.status, diagnostics.STATUS_OK)
-        self.assertIn("wheel", check.message)
+        self.assertIn("permitted", check.message)
 
-    def test_member_of_sudo_is_ok(self):
-        with mock.patch("diagnostics._user_admin_groups", return_value=["sudo"]):
-            check = diagnostics._wpa_dbus_admin_group_check()
-        self.assertEqual(check.status, diagnostics.STATUS_OK)
-        self.assertIn("sudo", check.message)
-
-    def test_missing_admin_group_warns(self):
-        with mock.patch("diagnostics._user_admin_groups", return_value=[]):
-            check = diagnostics._wpa_dbus_admin_group_check()
+    def test_access_denied_without_admin_group_warns(self):
+        with mock.patch("diagnostics.shutil.which", return_value="/usr/bin/gdbus"), \
+                mock.patch("diagnostics._user_admin_groups", return_value=[]), \
+                mock.patch(
+                    "diagnostics._run",
+                    return_value=_completed(
+                        "Error: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: "
+                        "Rejected send message",
+                        returncode=1,
+                    ),
+                ):
+            check = diagnostics._wpa_dbus_set_check()
         self.assertEqual(check.status, diagnostics.STATUS_WARN)
+        self.assertIn("denied", check.message)
         self.assertIn("wheel", check.detail)
         self.assertIn("sudo", check.detail)
 
-    def test_run_diagnostics_includes_admin_group_check(self):
-        with mock.patch("diagnostics._wpa_dbus_admin_group_check") as probe, \
+    def test_access_denied_with_admin_group_warns_about_policy(self):
+        with mock.patch("diagnostics.shutil.which", return_value="/usr/bin/gdbus"), \
+                mock.patch("diagnostics._user_admin_groups", return_value=["wheel"]), \
+                mock.patch(
+                    "diagnostics._run",
+                    return_value=_completed(
+                        "Error: GDBus.Error:org.freedesktop.DBus.Error.AccessDenied: "
+                        "Rejected send message",
+                        returncode=1,
+                    ),
+                ):
+            check = diagnostics._wpa_dbus_set_check()
+        self.assertEqual(check.status, diagnostics.STATUS_WARN)
+        self.assertIn("dbus", check.detail.lower())
+
+    def test_missing_gdbus_warns(self):
+        with mock.patch("diagnostics.shutil.which", return_value=None):
+            check = diagnostics._wpa_dbus_set_check()
+        self.assertEqual(check.status, diagnostics.STATUS_WARN)
+        self.assertIn("gdbus", check.message)
+
+    def test_run_diagnostics_includes_set_check(self):
+        with mock.patch("diagnostics._wpa_dbus_set_check") as probe, \
                 mock.patch("diagnostics._firewall_check"):
             probe.return_value = diagnostics.Check(
-                "wpa D-Bus group", diagnostics.STATUS_OK, "member of wheel",
+                "wpa D-Bus Set", diagnostics.STATUS_OK, "Properties.Set on wpa_supplicant is permitted",
             )
             report = diagnostics.run_diagnostics(skip_firewall=True)
         probe.assert_called_once()
         names = [check.name for check in report.checks]
-        self.assertIn("wpa D-Bus group", names)
+        self.assertIn("wpa D-Bus Set", names)
 
 
 class WpaDbusPolicyConfTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Scope the FluxCast wpa_supplicant D-Bus policy to `wheel`/`sudo` instead of `context="default"`, so unprivileged local accounts can no longer call `Properties.Set` on the system supplicant ([#103](https://github.com/IlyaP358/fluxcast/issues/103)).
- Add a `--doctor` check that reports whether the current user is in an admin group (needed for device name / GO intent).
- Refresh the AppImage first-run setup when the installed policy content changes, so existing insecure installs get upgraded.

## Test plan
- [x] `python3 -m unittest tests.test_diagnostics -v`
- [x] Install/update `meta/zz-dev.fluxcast.wpa-supplicant.conf` and `sudo systemctl reload dbus`
- [x] As a normal non-admin user, confirm `Properties.Set` is `AccessDenied` (bus drop), while `wheel`/`sudo` members can still set `P2PDeviceConfig`
- [x] `python3 src/main.py --doctor` shows `wpa D-Bus group` ok/warn based on membership
- [x] AppImage/setup path replaces an older `context="default"` policy file when content differs

Fixes #103
