### PR TITLE
Restrict DLNA/Cast stream server access (issue #102)

### DIFF
--- a/src/capture/capture.py
+++ b/src/capture/capture.py
@@ -7,7 +7,19 @@ import sys
 import time
 from typing import Any, Optional, NamedTuple
 
+import server as stream_server
+
 FFMPEG_PATH = shutil.which("ffmpeg") or "/usr/sbin/ffmpeg"
+
+
+def _prepare_capture_hls_dir() -> str:
+    hls_dir = stream_server.HLS_DIR
+    os.makedirs(hls_dir, mode=0o700, exist_ok=True)
+    try:
+        os.chmod(hls_dir, 0o700)
+    except OSError:
+        pass
+    return hls_dir
 
 
 class Monitor(NamedTuple):
@@ -272,6 +284,7 @@ def _start_capture_wf_recorder(
         out_w, out_h = 1920, 1080
 
     audio_monitor = _default_audio_monitor()
+    hls_dir = _prepare_capture_hls_dir()
 
     cmd = [
         "wf-recorder",
@@ -292,17 +305,12 @@ def _start_capture_wf_recorder(
         "-p", "hls_flags=append_list",
         "-p", "pix_fmt=yuv420p",
         "-p", "profile=main",
-        "-f", "/tmp/fluxcast/stream.m3u8",
+        "-f", os.path.join(hls_dir, "stream.m3u8"),
         "-o", monitor.name,
     ]
 
     print(f"[FluxCast] Capturing Wayland monitor : {monitor.name} ({src_res})")
     print(f"[FluxCast] Output: {out_w}x{out_h}, audio: {audio_monitor}")
-
-    hls_dir = "/tmp/fluxcast"
-    if os.path.exists(hls_dir):
-        shutil.rmtree(hls_dir)
-    os.makedirs(hls_dir, exist_ok=True)
 
     try:
         process = subprocess.Popen(
@@ -376,10 +384,7 @@ def _start_capture_portal(
         except (ValueError, AttributeError):
             pass
 
-    hls_dir = "/tmp/fluxcast"
-    if os.path.exists(hls_dir):
-        shutil.rmtree(hls_dir)
-    os.makedirs(hls_dir, exist_ok=True)
+    hls_dir = _prepare_capture_hls_dir()
 
     audio_monitor = _default_audio_monitor()
     audio_enc = (
@@ -503,11 +508,7 @@ def _start_capture_x11grab(
     src_res = f"{monitor.width}x{monitor.height}"
     out_res = output_resolution or src_res
     audio_monitor = _default_audio_monitor()
-    hls_dir = "/tmp/fluxcast"
-
-    if os.path.exists(hls_dir):
-        shutil.rmtree(hls_dir)
-    os.makedirs(hls_dir, exist_ok=True)
+    hls_dir = _prepare_capture_hls_dir()
 
     cmd = [
         ffmpeg,

--- a/src/main.py
+++ b/src/main.py
@@ -65,7 +65,15 @@ import sys
 import termios
 
 from capture import prompt_monitor, start_capture, stop_capture
-from server import HLS_DIR, CorsHLSRequestHandler, HLSRequestHandler, StreamServer
+from server import (
+    HLS_DIR,
+    CorsHLSRequestHandler,
+    HLSRequestHandler,
+    StreamServer,
+    device_client_ip,
+    new_session_id,
+    prepare_hls_dir,
+)
 
 
 def get_local_ip() -> str:
@@ -285,7 +293,8 @@ def main() -> None:
         return
 
     host = args.host or get_local_ip()
-    session_id = f"session-{int(time.time())}"
+    session_id = new_session_id()
+    prepare_hls_dir(session_id)
     if args.transport == "live-ts":
         stream_name = "live.ts"
     elif args.transport == "progressive-ts":
@@ -348,11 +357,18 @@ def main() -> None:
     )
     print("[FluxCast] Screen capture started.")
 
-    # HTTP server serves the HLS playlist and MPEG-TS segments from /tmp/fluxcast.
+    # HTTP server serves the HLS playlist and MPEG-TS segments from the
+    # per-session directory under /tmp/fluxcast. Bind only to the advertised
+    # LAN address; session prefix + client ACL are enforced in the handler.
     # Cast uses a CORS-enabled handler (Chromecast needs it for HLS); dlna keeps
     # the plain handler so its responses stay byte-identical to before.
     handler_class = CorsHLSRequestHandler if args.protocol == "cast" else HLSRequestHandler
-    stream_server = StreamServer(host="0.0.0.0", port=args.port, handler_class=handler_class)
+    stream_server = StreamServer(
+        host=host,
+        port=args.port,
+        handler_class=handler_class,
+        session_id=session_id,
+    )
     stream_server.start()
     print(f"[FluxCast] HTTP server: {stream_url}")
     print(f"[FluxCast] Session: {session_id}")
@@ -368,17 +384,20 @@ def main() -> None:
         from dlna import discover_devices, prompt_device, start_cast
         devices = discover_devices(timeout=args.discover_timeout)
         tv = prompt_device(devices, args.device_name)
+        stream_server.allow_client(device_client_ip(tv, "dlna"))
         start_cast(tv, stream_url)
 
     else:  # cast protocol
         from cast import discover_devices, connect_by_ip, prompt_device, start_cast
         if args.tv_ip:
             tv = connect_by_ip(args.tv_ip)
+            stream_server.allow_client(device_client_ip(tv, "cast"))
             start_cast(tv, stream_url)
         else:
             devices = discover_devices(timeout=args.discover_timeout)
             tv = prompt_device(devices, args.device_name)
             print(f"[FluxCast] Found: {tv.cast_info.friendly_name}")
+            stream_server.allow_client(device_client_ip(tv, "cast"))
             start_cast(tv, stream_url)
 
     print("[FluxCast] Casting started. Press Ctrl+C to stop.")

--- a/src/main.py
+++ b/src/main.py
@@ -65,8 +65,8 @@ import sys
 import termios
 
 from capture import prompt_monitor, start_capture, stop_capture
+import server
 from server import (
-    HLS_DIR,
     CorsHLSRequestHandler,
     HLSRequestHandler,
     StreamServer,
@@ -223,12 +223,14 @@ def _restore_term(saved) -> None:
 
 
 def _wait_for_hls_segments(required_segments: int = 2, timeout: float = 15.0) -> bool:
-    playlist = os.path.join(HLS_DIR, "stream.m3u8")
+    # Read dynamically — prepare_hls_dir() reassigns server.HLS_DIR per session.
+    hls_dir = server.HLS_DIR
+    playlist = os.path.join(hls_dir, "stream.m3u8")
     start = time.monotonic()
 
     while time.monotonic() - start < timeout:
         segments = []
-        for path in glob.glob(os.path.join(HLS_DIR, "stream*.ts")):
+        for path in glob.glob(os.path.join(hls_dir, "stream*.ts")):
             try:
                 if os.path.getsize(path) > 0:
                     segments.append(path)

--- a/src/server.py
+++ b/src/server.py
@@ -43,7 +43,9 @@ def prepare_hls_dir(session_id: str) -> str:
     session_dir = os.path.join(HLS_BASE, session_id)
     if os.path.isdir(HLS_BASE):
         shutil.rmtree(HLS_BASE)
+    # makedirs only applies mode to the leaf; chmod both base and session dir.
     os.makedirs(session_dir, mode=0o700)
+    os.chmod(HLS_BASE, 0o700)
     os.chmod(session_dir, 0o700)
     HLS_DIR = session_dir
     PROGRESSIVE_TS_PATH = os.path.join(HLS_DIR, "progressive.ts")
@@ -278,8 +280,6 @@ class HLSRequestHandler(http.server.BaseHTTPRequestHandler):
             basename.startswith("stream") and basename.endswith(".ts")
         ):
             normalized = basename
-        elif basename in ("live.ts", "progressive.ts"):
-            return None
         return os.path.join(HLS_DIR, normalized)
 
     def _send_common_headers(self, local_path: str) -> None:

--- a/src/server.py
+++ b/src/server.py
@@ -1,5 +1,7 @@
 import http.server
 import os
+import secrets
+import shutil
 import socketserver
 import threading
 import time
@@ -7,7 +9,8 @@ from typing import Optional
 from urllib.parse import unquote, urlsplit
 
 
-HLS_DIR = "/tmp/fluxcast"
+HLS_BASE = "/tmp/fluxcast"
+HLS_DIR = HLS_BASE
 HLS_SEGMENT_SECONDS = 1.0
 LIVE_TS_SIZE = 1_000_000_000_000
 LIVE_TS_PREROLL_SEGMENTS = 1
@@ -28,6 +31,35 @@ TS_CONTENT_FEATURES = (
     "DLNA.ORG_CI=0;"
     f"DLNA.ORG_FLAGS={DLNA_FLAGS}"
 )
+
+
+def new_session_id() -> str:
+    return f"session-{secrets.token_urlsafe(16)}"
+
+
+def prepare_hls_dir(session_id: str) -> str:
+    """Create a per-session segment directory with mode 0700."""
+    global HLS_DIR, PROGRESSIVE_TS_PATH
+    session_dir = os.path.join(HLS_BASE, session_id)
+    if os.path.isdir(HLS_BASE):
+        shutil.rmtree(HLS_BASE)
+    os.makedirs(session_dir, mode=0o700)
+    os.chmod(session_dir, 0o700)
+    HLS_DIR = session_dir
+    PROGRESSIVE_TS_PATH = os.path.join(HLS_DIR, "progressive.ts")
+    return HLS_DIR
+
+
+def device_client_ip(device, protocol: str) -> str:
+    if protocol == "cast":
+        return device.cast_info.host
+    if protocol == "dlna":
+        location = getattr(device, "location", None) or ""
+        host = urlsplit(location).hostname
+        if not host:
+            raise ValueError("DLNA device has no location host")
+        return host
+    raise ValueError(f"unsupported protocol for client ACL: {protocol}")
 
 
 def _url_path(raw_path: str) -> str:
@@ -173,7 +205,11 @@ class ProgressiveTS:
             return self._started and self._generation == generation
 
     def _run(self, generation: int) -> None:
-        os.makedirs(HLS_DIR, exist_ok=True)
+        os.makedirs(HLS_DIR, mode=0o700, exist_ok=True)
+        try:
+            os.chmod(HLS_DIR, 0o700)
+        except OSError:
+            pass
         try:
             open(PROGRESSIVE_TS_PATH, "wb").close()
         except OSError:
@@ -215,10 +251,25 @@ class HLSRequestHandler(http.server.BaseHTTPRequestHandler):
     def log_message(self, format, *args):
         return
 
+    def _authorize(self) -> bool:
+        allowed = getattr(self.server, "allowed_client", None)
+        if not allowed or self.client_address[0] != allowed:
+            self._send_empty(403)
+            return False
+
+        session_id = getattr(self.server, "session_id", None)
+        if session_id:
+            path = _url_path(self.path)
+            prefix = f"/{session_id}/"
+            if not path.startswith(prefix):
+                self._send_empty(404)
+                return False
+        return True
+
     def _local_path(self) -> Optional[str]:
         path = _url_path(self.path).lstrip("/")
         if not path:
-            path = "stream.m3u8"
+            return None
         normalized = os.path.normpath(path)
         if normalized.startswith("..") or os.path.isabs(normalized):
             return None
@@ -227,6 +278,8 @@ class HLSRequestHandler(http.server.BaseHTTPRequestHandler):
             basename.startswith("stream") and basename.endswith(".ts")
         ):
             normalized = basename
+        elif basename in ("live.ts", "progressive.ts"):
+            return None
         return os.path.join(HLS_DIR, normalized)
 
     def _send_common_headers(self, local_path: str) -> None:
@@ -241,6 +294,8 @@ class HLSRequestHandler(http.server.BaseHTTPRequestHandler):
 
     def _send_empty(self, status: int) -> None:
         self.close_connection = True
+        if status in (403, 404):
+            print(f"[FluxCast Server] {status} {self.client_address[0]} -> {self.path}")
         self.send_response(status)
         self.send_header("Content-Length", "0")
         self.send_header("Connection", "close")
@@ -674,6 +729,8 @@ class HLSRequestHandler(http.server.BaseHTTPRequestHandler):
             pass
 
     def do_HEAD(self):
+        if not self._authorize():
+            return
         path = _url_path(self.path)
         if path.endswith("/progressive.ts"):
             self._serve_progressive_ts(send_body=False)
@@ -684,6 +741,8 @@ class HLSRequestHandler(http.server.BaseHTTPRequestHandler):
         self._serve_file(send_body=False)
 
     def do_GET(self):
+        if not self._authorize():
+            return
         path = _url_path(self.path)
         if path.endswith("/progressive.ts"):
             self._serve_progressive_ts(send_body=True)
@@ -709,33 +768,49 @@ class CorsHLSRequestHandler(HLSRequestHandler):
         super().end_headers()
 
     def do_OPTIONS(self):
+        if not self._authorize():
+            return
         self.close_connection = True
         self.send_response(200)
         self.send_header("Content-Length", "0")
         self.send_header("Connection", "close")
         self.end_headers()
 
-    def _send_empty(self, status: int) -> None:
-        if status == 404:
-            print(f"[FluxCast Server] 404 {self.client_address[0]} -> {self.path}")
-        super()._send_empty(status)
-
 
 class StreamServer:
-    def __init__(self, host: str = "0.0.0.0", port: int = 8080,
-                 handler_class=HLSRequestHandler):
+    def __init__(
+        self,
+        host: str = "0.0.0.0",
+        port: int = 8080,
+        handler_class=HLSRequestHandler,
+        session_id: Optional[str] = None,
+        allowed_client: Optional[str] = None,
+    ):
         self.host = host
         self.port = port
         self.handler_class = handler_class
+        self.session_id = session_id
+        self.allowed_client = allowed_client
         self._server: Optional[socketserver.TCPServer] = None
         self._thread: Optional[threading.Thread] = None
 
+    def allow_client(self, client_ip: str) -> None:
+        self.allowed_client = client_ip
+        if self._server is not None:
+            self._server.allowed_client = client_ip
+
     def start(self, capture_process=None) -> None:
-        os.makedirs(HLS_DIR, exist_ok=True)
+        os.makedirs(HLS_DIR, mode=0o700, exist_ok=True)
+        try:
+            os.chmod(HLS_DIR, 0o700)
+        except OSError:
+            pass
         _progressive_ts.reset()
         self._server = http.server.ThreadingHTTPServer(
             (self.host, self.port), self.handler_class
         )
+        self._server.session_id = self.session_id
+        self._server.allowed_client = self.allowed_client
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
         self._thread.start()
 

--- a/tests/test_stream_access.py
+++ b/tests/test_stream_access.py
@@ -1,0 +1,130 @@
+import os
+import stat
+import sys
+import tempfile
+import unittest
+import urllib.error
+import urllib.request
+from http.client import HTTPConnection
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import server  # noqa: E402
+
+
+class StreamAccessTest(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmpdir.cleanup)
+        self.hls_dir = os.path.join(self._tmpdir.name, "session-test")
+        os.makedirs(self.hls_dir, mode=0o700)
+        playlist = os.path.join(self.hls_dir, "stream.m3u8")
+        with open(playlist, "w", encoding="utf-8") as fh:
+            fh.write("#EXTM3U\n#EXT-X-TARGETDURATION:1\n#EXTINF:1.0,\nstream0.ts\n")
+        with open(os.path.join(self.hls_dir, "stream0.ts"), "wb") as fh:
+            fh.write(b"\x00" * 64)
+
+        self._hls_dir_patch = mock.patch.object(server, "HLS_DIR", self.hls_dir)
+        self._hls_dir_patch.start()
+        self.addCleanup(self._hls_dir_patch.stop)
+
+        self.session_id = "session-testtoken"
+        self.allowed_client = "127.0.0.1"
+        self.stream_server = server.StreamServer(
+            host="127.0.0.1",
+            port=0,
+            handler_class=server.HLSRequestHandler,
+            session_id=self.session_id,
+            allowed_client=self.allowed_client,
+        )
+        self.stream_server.start()
+        self.addCleanup(self.stream_server.stop)
+        self.port = self.stream_server._server.server_address[1]
+
+    def _status(self, path: str, host: str = "127.0.0.1") -> int:
+        conn = HTTPConnection(host, self.port, timeout=2)
+        try:
+            conn.request("HEAD", path)
+            return conn.getresponse().status
+        finally:
+            conn.close()
+
+    def test_binds_only_to_requested_host(self):
+        host, _port = self.stream_server._server.server_address
+        self.assertEqual(host, "127.0.0.1")
+
+    def test_rejects_bare_root_without_session_prefix(self):
+        self.assertEqual(self._status("/"), 404)
+
+    def test_rejects_unprefixed_live_ts(self):
+        self.assertEqual(self._status("/live.ts"), 404)
+
+    def test_rejects_wrong_session_prefix(self):
+        self.assertEqual(self._status("/session-other/stream.m3u8"), 404)
+
+    def test_allows_correct_session_and_client(self):
+        self.assertEqual(self._status(f"/{self.session_id}/stream.m3u8"), 200)
+
+    def test_rejects_disallowed_client(self):
+        self.stream_server.allow_client("192.0.2.10")
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            urllib.request.urlopen(
+                f"http://127.0.0.1:{self.port}/{self.session_id}/stream.m3u8",
+                timeout=2,
+            )
+        self.assertEqual(ctx.exception.code, 403)
+        ctx.exception.close()
+
+    def test_rejects_before_allowed_client_is_set(self):
+        locked = server.StreamServer(
+            host="127.0.0.1",
+            port=0,
+            handler_class=server.HLSRequestHandler,
+            session_id=self.session_id,
+            allowed_client=None,
+        )
+        locked.start()
+        self.addCleanup(locked.stop)
+        port = locked._server.server_address[1]
+        conn = HTTPConnection("127.0.0.1", port, timeout=2)
+        try:
+            conn.request("HEAD", f"/{self.session_id}/stream.m3u8")
+            self.assertEqual(conn.getresponse().status, 403)
+        finally:
+            conn.close()
+
+
+class SessionSetupTest(unittest.TestCase):
+    def test_prepare_hls_dir_uses_session_subdir_mode_0700(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(server, "HLS_BASE", tmp):
+                path = server.prepare_hls_dir("session-abc")
+            self.assertEqual(path, os.path.join(tmp, "session-abc"))
+            self.assertTrue(os.path.isdir(path))
+            mode = stat.S_IMODE(os.stat(path).st_mode)
+            self.assertEqual(mode, 0o700)
+            self.assertEqual(server.HLS_DIR, path)
+
+    def test_new_session_id_uses_secrets(self):
+        with mock.patch("secrets.token_urlsafe", return_value="tok123") as token:
+            # Import after patch path — exercise helper once it exists
+            session_id = server.new_session_id()
+        token.assert_called_once()
+        self.assertEqual(session_id, "session-tok123")
+
+
+class DeviceIpTest(unittest.TestCase):
+    def test_cast_device_ip(self):
+        device = mock.Mock()
+        device.cast_info.host = "192.168.1.50"
+        self.assertEqual(server.device_client_ip(device, protocol="cast"), "192.168.1.50")
+
+    def test_dlna_device_ip_from_location(self):
+        device = mock.Mock()
+        device.location = "http://192.168.1.60:9197/DeviceDescription.xml"
+        self.assertEqual(server.device_client_ip(device, protocol="dlna"), "192.168.1.60")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stream_access.py
+++ b/tests/test_stream_access.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+import main  # noqa: E402
 import server  # noqa: E402
 
 
@@ -104,6 +105,8 @@ class SessionSetupTest(unittest.TestCase):
             self.assertTrue(os.path.isdir(path))
             mode = stat.S_IMODE(os.stat(path).st_mode)
             self.assertEqual(mode, 0o700)
+            base_mode = stat.S_IMODE(os.stat(tmp).st_mode)
+            self.assertEqual(base_mode, 0o700)
             self.assertEqual(server.HLS_DIR, path)
 
     def test_new_session_id_uses_secrets(self):
@@ -112,6 +115,29 @@ class SessionSetupTest(unittest.TestCase):
             session_id = server.new_session_id()
         token.assert_called_once()
         self.assertEqual(session_id, "session-tok123")
+
+
+class MainHlsDirBindingTest(unittest.TestCase):
+    def test_wait_for_hls_segments_follows_prepare_hls_dir(self):
+        """main must read server.HLS_DIR dynamically, not import it by value."""
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(server, "HLS_BASE", tmp):
+                session_dir = server.prepare_hls_dir("session-binding")
+            playlist = os.path.join(session_dir, "stream.m3u8")
+            with open(playlist, "w", encoding="utf-8") as fh:
+                fh.write(
+                    "#EXTM3U\n#EXT-X-TARGETDURATION:1\n"
+                    "#EXTINF:1.0,\nstream0.ts\n"
+                    "#EXTINF:1.0,\nstream1.ts\n"
+                )
+            for name in ("stream0.ts", "stream1.ts"):
+                with open(os.path.join(session_dir, name), "wb") as fh:
+                    fh.write(b"\x00" * 64)
+
+            # Would time out if main still pointed at the pre-session HLS_DIR.
+            self.assertTrue(
+                main._wait_for_hls_segments(required_segments=2, timeout=1.0)
+            )
 
 
 class DeviceIpTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Bind the DLNA/Cast HTTP stream server to the advertised LAN address instead of `0.0.0.0`, and require an unpredictable `secrets.token_urlsafe` session URL prefix.
- Allow only the selected TV/Chromecast client IP (403 until set / for other hosts), and store HLS segments under a per-session directory with mode `0700`.
- Adds unit tests covering bind address, session prefix, client ACL, and directory permissions. Fixes #102.

## Test plan
- [ ] `python -m unittest tests.test_stream_access -v`
- [ ] Start a DLNA or Cast session; confirm the TV still plays from the session URL
- [ ] From another machine on the LAN: `curl -sI http://<host>:8080/` is refused (404/403) while the TV keeps playing
- [ ] Confirm `/tmp/fluxcast/<session-id>/` exists with mode `0700`
- [ ] Confirm WFD path is unchanged


Made with [Cursor](https://cursor.com)