### PR TITLE
Add a direct wpa_supplicant P2P backend for WFD (--wfd-p2p-backend wpas)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ python3 src/main.py --protocol wfd --wfd-p2p-backend wpas --wfd-p2p-channel 6
 ```
 
 Needs the D-Bus policy in `meta/zz-dev.fluxcast.wpa-supplicant.conf`
-installed to `/usr/share/dbus-1/system.d/` (root, or a user in the `netdev`
-group, can then run it without sudo - see the file for details).
+installed to `/usr/share/dbus-1/system.d/`. On Debian/Ubuntu, a user in the
+`netdev` group can then run it without sudo; elsewhere (including Arch)
+it falls back to sudo - see the file for details.
 
 ## What Works Best
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ python3 src/main.py --protocol wfd --wfd-capture-backend wf-recorder
 python3 src/main.py --protocol wfd --wfd-capture-backend x11grab
 ```
 
+WFD P2P connection troubleshooting - talk to wpa_supplicant directly instead
+of going through NetworkManager, and optionally pin the group to a 2.4GHz
+channel for sinks that don't support Wi-Fi Direct on 5GHz:
+
+```bash
+python3 src/main.py --protocol wfd --wfd-p2p-backend wpas
+python3 src/main.py --protocol wfd --wfd-p2p-backend wpas --wfd-p2p-channel 6
+```
+
+Needs the D-Bus policy in `meta/zz-dev.fluxcast.wpa-supplicant.conf`
+installed to `/usr/share/dbus-1/system.d/` (root, or a user in the `netdev`
+group, can then run it without sudo - see the file for details).
+
 ## What Works Best
 
 ### WFD (Primary)

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -69,6 +69,8 @@ python3 src/main.py --protocol cast
 - `--wfd-interface IFACE`
 - `--wfd-timeout SEC`
 - `--wfd-go-intent 0-15`
+- `--wfd-p2p-backend nm|wpas` talk to wpa_supplicant directly instead of NetworkManager (default `nm`)
+- `--wfd-p2p-channel 1|6|11` force the P2P group onto this 2.4GHz channel (`wpas` backend only)
 - `--wfd-uibc` enable the input back channel (control the desktop from the sink)
 - `--wfd-monitor NAME` **deprecated** alias for `--monitor` (kept for compatibility)
 
@@ -196,6 +198,21 @@ and protocol selection remain controlled by the tray and cannot be set here.
     session; raise it only if a specific sink requires a higher intent.
   - Does not claim or require that the TV becomes the group owner or that the
     P2P address range changes.
+- `--wfd-p2p-backend`
+  - `nm` (default) brings up the P2P link through NetworkManager.
+  - `wpas` talks to wpa_supplicant's own D-Bus interface directly instead,
+    which exposes controls NetworkManager's API doesn't - notably
+    `--wfd-p2p-channel` below. Also useful when a P2P connection needs
+    closer debugging, since it logs each step of the raw negotiation.
+  - Needs the D-Bus policy in `meta/zz-dev.fluxcast.wpa-supplicant.conf`
+    installed (root, or a user in the `netdev` group, can run it without
+    sudo - see the file for details).
+- `--wfd-p2p-channel`
+  - Forces the P2P group onto channel `1`, `6`, or `11` (2.4GHz) instead of
+    letting the driver pick. Only used by `--wfd-p2p-backend wpas`.
+  - Some sinks only support Wi-Fi Direct on 2.4GHz and silently never
+    associate if the group forms on 5GHz - GO Negotiation completes fine,
+    but the sink never shows up at the 802.11 level.
 - `--wfd-monitor NAME`
   - **Deprecated** alias for `--monitor`, kept for backward compatibility. Use `--monitor` instead.
 

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -205,8 +205,9 @@ and protocol selection remain controlled by the tray and cannot be set here.
     `--wfd-p2p-channel` below. Also useful when a P2P connection needs
     closer debugging, since it logs each step of the raw negotiation.
   - Needs the D-Bus policy in `meta/zz-dev.fluxcast.wpa-supplicant.conf`
-    installed (root, or a user in the `netdev` group, can run it without
-    sudo - see the file for details).
+    installed. On Debian/Ubuntu, a user in the `netdev` group can then run
+    it without sudo; elsewhere (including Arch, this project's primary
+    platform) it falls back to sudo - see the file for details.
 - `--wfd-p2p-channel`
   - Forces the P2P group onto channel `1`, `6`, or `11` (2.4GHz) instead of
     letting the driver pick. Only used by `--wfd-p2p-backend wpas`.

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -214,6 +214,14 @@ and protocol selection remain controlled by the tray and cannot be set here.
   - Some sinks only support Wi-Fi Direct on 2.4GHz and silently never
     associate if the group forms on 5GHz - GO Negotiation completes fine,
     but the sink never shows up at the 802.11 level.
+  - Only takes effect when we end up as Group Owner, since that's the side
+    that picks the operating channel. `--wfd-go-intent` defaults to `0` so
+    the sink becomes GO on most sinks, which means this flag does nothing
+    by default - pair it with `--wfd-go-intent 15` if you need the channel
+    forced deterministically. FluxCast warns if it looks like that pairing
+    is missing, but never raises GO intent on its own: `go_intent 0` is a
+    deliberate fix for some sinks (see #72), and silently overriding it
+    would break those.
 - `--wfd-monitor NAME`
   - **Deprecated** alias for `--monitor`, kept for backward compatibility. Use `--monitor` instead.
 

--- a/meta/zz-dev.fluxcast.wpa-supplicant.conf
+++ b/meta/zz-dev.fluxcast.wpa-supplicant.conf
@@ -11,4 +11,34 @@
            send_member="Set"/>
     <allow receive_sender="fi.w1.wpa_supplicant1"/>
   </policy>
+
+  <!--
+    Unlike NetworkManager, wpa_supplicant has no polkit integration, so it
+    can never consult a polkit action at call time - all of its D-Bus
+    authorization comes from this static, group-based policy. netdev is a
+    natural scope for the P2P actions below: it's already the group
+    wpa_supplicant's own ctrl_interface socket is restricted to (see
+    Group=netdev in wpa_supplicant.service), so a member of it already
+    holds meaningful local Wi-Fi control on this system - this just extends
+    an existing trust boundary rather than opening a new one. Root is
+    always allowed separately by dbus-daemon's own implicit rules.
+
+    This covers P2P negotiation only. The IP-layer side of the wpas backend
+    (raw ip/dnsmasq/dhcpcd commands, not D-Bus calls) still needs real root
+    regardless of netdev membership.
+  -->
+  <policy group="netdev">
+    <allow send_destination="fi.w1.wpa_supplicant1"
+           send_interface="fi.w1.wpa_supplicant1.Interface.P2PDevice"
+           send_member="Find"/>
+    <allow send_destination="fi.w1.wpa_supplicant1"
+           send_interface="fi.w1.wpa_supplicant1.Interface.P2PDevice"
+           send_member="Connect"/>
+    <allow send_destination="fi.w1.wpa_supplicant1"
+           send_interface="fi.w1.wpa_supplicant1.Interface.P2PDevice"
+           send_member="StopFind"/>
+    <allow send_destination="fi.w1.wpa_supplicant1"
+           send_interface="fi.w1.wpa_supplicant1.Interface.P2PDevice"
+           send_member="GroupRemove"/>
+  </policy>
 </busconfig>

--- a/meta/zz-dev.fluxcast.wpa-supplicant.conf
+++ b/meta/zz-dev.fluxcast.wpa-supplicant.conf
@@ -15,17 +15,23 @@
   <!--
     Unlike NetworkManager, wpa_supplicant has no polkit integration, so it
     can never consult a polkit action at call time - all of its D-Bus
-    authorization comes from this static, group-based policy. netdev is a
-    natural scope for the P2P actions below: it's already the group
-    wpa_supplicant's own ctrl_interface socket is restricted to (see
-    Group=netdev in wpa_supplicant.service), so a member of it already
-    holds meaningful local Wi-Fi control on this system - this just extends
-    an existing trust boundary rather than opening a new one. Root is
-    always allowed separately by dbus-daemon's own implicit rules.
+    authorization comes from this static, group-based policy.
+
+    The netdev group below is a Debian/Ubuntu convention: their
+    wpa_supplicant.service sets Group=netdev, so a netdev member already
+    has access to wpa_supplicant's own ctrl_interface socket, and granting
+    these four P2P actions to the same group just extends a trust boundary
+    that already exists there. Arch (this project's primary platform) has
+    no such group and no Group= line on any of its wpa_supplicant units,
+    so this block is a no-op there - dbus-daemon logs "unknown group" and
+    moves on. It's harmless either way: root is always allowed separately
+    by dbus-daemon's own implicit rules, and anyone outside the netdev
+    group (which, on a distro without it, is everyone) just falls back to
+    sudo, same as before this policy existed.
 
     This covers P2P negotiation only. The IP-layer side of the wpas backend
     (raw ip/dnsmasq/dhcpcd commands, not D-Bus calls) still needs real root
-    regardless of netdev membership.
+    regardless of group membership.
   -->
   <policy group="netdev">
     <allow send_destination="fi.w1.wpa_supplicant1"

--- a/src/main.py
+++ b/src/main.py
@@ -183,8 +183,29 @@ def parse_args() -> argparse.Namespace:
                      help="P2P group-owner intent (0-15); 0 forces the TV to be "
                           "the group owner, which most Miracast TVs require to "
                           "start the session (default: 0)")
+    wfd.add_argument("--wfd-p2p-channel", type=int, default=None, dest="wfd_p2p_channel",
+                     choices=[1, 6, 11],
+                     help="Force the P2P group onto this 2.4GHz channel instead of "
+                          "letting the driver pick (only used by --wfd-p2p-backend "
+                          "wpas). Some WFD sinks only support Wi-Fi Direct on "
+                          "2.4GHz, and silently never associate if the group forms "
+                          "on 5GHz - GO Negotiation completes fine, but the sink "
+                          "never shows up at the 802.11 level. Default: unset "
+                          "(driver picks the channel).")
     wfd.add_argument("--wfd-monitor", default=None, dest="monitor_name",
                      help="Deprecated alias for --monitor, kept for compatibility")
+    wfd.add_argument("--wfd-p2p-backend", default="nm", dest="wfd_p2p_backend",
+                     choices=["nm", "wpas"],
+                     help="How to bring up the P2P link: 'nm' uses "
+                          "NetworkManager (default); 'wpas' talks to "
+                          "wpa_supplicant directly instead, which exposes "
+                          "controls NetworkManager's own P2P API doesn't - "
+                          "notably --wfd-p2p-channel below. Also useful for "
+                          "debugging P2P/WPS negotiation issues, since it "
+                          "logs each step of the raw exchange. Needs the "
+                          "D-Bus policy in "
+                          "meta/zz-dev.fluxcast.wpa-supplicant.conf (root "
+                          "or netdev group).")
     wfd.add_argument("--wfd-uibc", action="store_true", dest="wfd_uibc",
                      help="Experimental: accept touch/mouse input back from the "
                           "sink (TV/tablet) and inject it locally via uinput. "

--- a/src/wfd/p2p/dbus.py
+++ b/src/wfd/p2p/dbus.py
@@ -91,15 +91,15 @@ def _gdbus_call(args: list[str], timeout: float = 5.0,
                  privileged: bool = False) -> subprocess.CompletedProcess[str]:
     """privileged=True marks a call that needs elevated D-Bus access:
     P2PDevice.Find/Connect/StopFind/GroupRemove, which our D-Bus policy
-    (meta/zz-dev.fluxcast.wpa-supplicant.conf) only grants to root and to
-    the netdev group - unprivileged callers get Properties.Get/Set only.
+    (meta/zz-dev.fluxcast.wpa-supplicant.conf) grants to root, plus the
+    netdev group on Debian/Ubuntu (see that file's comment - Arch has no
+    such group, so there this always falls back to sudo below).
 
     wpa_supplicant has no polkit integration, so unlike NetworkManager it
     can't prompt for authorization at call time - the policy grant is
     static, decided by the caller's uid/gid before the call is ever made.
-    That means the right caller (root, or a netdev member) needs no sudo at
-    all here; we only escalate for everyone else, and only after actually
-    seeing the bus reject the call.
+    Where it applies, the right caller needs no sudo at all here; everyone
+    else escalates, and only after actually seeing the bus reject the call.
 
     Retrying under sudo after an AccessDenied is safe (not a double-fire of
     a stateful action): dbus-daemon enforces this policy at the message-
@@ -109,17 +109,21 @@ def _gdbus_call(args: list[str], timeout: float = 5.0,
     if not shutil.which("gdbus"):
         raise WFDNotReady("gdbus is required for NetworkManager Wi-Fi P2P discovery.")
     cmd = ["gdbus", "call", "--system", *args]
-    if not privileged:
-        return _run(cmd, timeout=timeout)
+    method = args[args.index("--method") + 1] if "--method" in args else "gdbus call"
+    try:
+        if not privileged:
+            return _run(cmd, timeout=timeout)
 
-    result = _run(cmd, timeout=timeout)
-    if result.returncode == 0 or "AccessDenied" not in (result.stderr or result.stdout or ""):
-        return result
-    # No -n: sudo's password prompt goes straight to the controlling
-    # terminal (/dev/tty) regardless of stdout/stderr capture here, so this
-    # still works interactively. Falls through instantly if the session's
-    # sudo timestamp is already cached from an earlier command.
-    return _run(["sudo", *cmd], timeout=timeout)
+        result = _run(cmd, timeout=timeout)
+        if result.returncode == 0 or "AccessDenied" not in (result.stderr or result.stdout or ""):
+            return result
+        # No -n: sudo's password prompt goes straight to the controlling
+        # terminal (/dev/tty) regardless of stdout/stderr capture here, so
+        # this still works interactively. Falls through instantly if the
+        # session's sudo timestamp is already cached from an earlier command.
+        return _run(["sudo", *cmd], timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise WFDNotReady(f"{method} timed out after {timeout:.0f}s") from exc
 
 def _nm_get_property(path: str, interface: str, prop: str) -> str:
     result = _gdbus_call([

--- a/src/wfd/p2p/dbus.py
+++ b/src/wfd/p2p/dbus.py
@@ -87,10 +87,39 @@ NM_DEVICE_REASON_NAMES = {
     54: "device-handler-failed",
 }
 
-def _gdbus_call(args: list[str], timeout: float = 5.0) -> subprocess.CompletedProcess[str]:
+def _gdbus_call(args: list[str], timeout: float = 5.0,
+                 privileged: bool = False) -> subprocess.CompletedProcess[str]:
+    """privileged=True marks a call that needs elevated D-Bus access:
+    P2PDevice.Find/Connect/StopFind/GroupRemove, which our D-Bus policy
+    (meta/zz-dev.fluxcast.wpa-supplicant.conf) only grants to root and to
+    the netdev group - unprivileged callers get Properties.Get/Set only.
+
+    wpa_supplicant has no polkit integration, so unlike NetworkManager it
+    can't prompt for authorization at call time - the policy grant is
+    static, decided by the caller's uid/gid before the call is ever made.
+    That means the right caller (root, or a netdev member) needs no sudo at
+    all here; we only escalate for everyone else, and only after actually
+    seeing the bus reject the call.
+
+    Retrying under sudo after an AccessDenied is safe (not a double-fire of
+    a stateful action): dbus-daemon enforces this policy at the message-
+    routing layer, before the call ever reaches wpa_supplicant, so a denied
+    first attempt has no observable side effect to duplicate.
+    """
     if not shutil.which("gdbus"):
         raise WFDNotReady("gdbus is required for NetworkManager Wi-Fi P2P discovery.")
-    return _run(["gdbus", "call", "--system", *args], timeout=timeout)
+    cmd = ["gdbus", "call", "--system", *args]
+    if not privileged:
+        return _run(cmd, timeout=timeout)
+
+    result = _run(cmd, timeout=timeout)
+    if result.returncode == 0 or "AccessDenied" not in (result.stderr or result.stdout or ""):
+        return result
+    # No -n: sudo's password prompt goes straight to the controlling
+    # terminal (/dev/tty) regardless of stdout/stderr capture here, so this
+    # still works interactively. Falls through instantly if the session's
+    # sudo timestamp is already cached from an earlier command.
+    return _run(["sudo", *cmd], timeout=timeout)
 
 def _nm_get_property(path: str, interface: str, prop: str) -> str:
     result = _gdbus_call([

--- a/src/wfd/p2p/device.py
+++ b/src/wfd/p2p/device.py
@@ -127,3 +127,49 @@ def _set_p2p_go_intent(iface: Optional[str], value: int,
     if not restoring:
         print("[FluxCast WFD] Warning: could not set P2P GO intent (connection will proceed with the default).")
     return None
+
+def _set_p2p_oper_channel(iface: Optional[str], channel: int, reg_class: int = 81) -> bool:
+    """Force the operating channel wpa_supplicant picks when we end up as GO.
+
+    Some WFD sinks only support Wi-Fi Direct on 2.4GHz. Left to its own
+    devices, a driver may still form the group on 5GHz, and a sink like
+    that will simply never associate - GO Negotiation completes normally,
+    but the sink never shows up at the 802.11 level at all. Forcing a
+    2.4GHz channel here works around that.
+
+    reg_class 81 is the standard worldwide "2.4GHz, 20MHz spacing, channels
+    1-13" global operating class (WFA/IEEE 802.11 Annex E) - the same value
+    Android's own Wi-Fi P2P framework uses. This reuses the same
+    P2PDeviceConfig struct as GOIntent above; wpa_supplicant merges
+    whichever keys are present rather than requiring the whole struct on
+    every call.
+    """
+    wpa_dest = "fi.w1.wpa_supplicant1"
+    wpa_iface = "fi.w1.wpa_supplicant1.Interface"
+
+    paths = _p2p_device_iface_paths(iface)
+    if not paths:
+        print("[FluxCast WFD] Warning: could not set P2P operating channel "
+              "(connection will proceed on whatever channel the driver picks).")
+        return False
+
+    for iface_path in paths:
+        try:
+            result = _gdbus_call([
+                "--dest", wpa_dest,
+                "--object-path", iface_path,
+                "--method", "org.freedesktop.DBus.Properties.Set",
+                f"{wpa_iface}.P2PDevice", "P2PDeviceConfig",
+                f"<{{'OperRegClass': <uint32 {reg_class}>, "
+                f"'OperChannel': <uint32 {channel}>}}>",
+            ], timeout=3.0)
+            if result.returncode == 0:
+                print(f"[FluxCast WFD] P2P operating channel forced to channel "
+                      f"{channel} (2.4GHz, reg class {reg_class}).")
+                return True
+        except Exception:
+            pass
+
+    print("[FluxCast WFD] Warning: could not set P2P operating channel "
+          "(connection will proceed on whatever channel the driver picks).")
+    return False

--- a/src/wfd/p2p/wpas.py
+++ b/src/wfd/p2p/wpas.py
@@ -238,6 +238,17 @@ def connect_via_wpa_supplicant(interface: Optional[str], peer_mac: str,
         data_iface = _wait_for_group_interface(interfaces_before)
         role = get_p2p_role(data_iface)
         print(f"[FluxCast WFD] P2P group formed on {data_iface}; our role: {role}")
+        if p2p_channel is not None and role != "P2P-GO":
+            # The operating channel is the Group Owner's call - forcing it
+            # on our end does nothing when the sink ends up as GO instead,
+            # which is the common case at the default go_intent=0. Warn
+            # rather than silently doing nothing, but never raise go_intent
+            # automatically: 0 is a deliberate fix for some sinks (#72),
+            # and overriding it here would break those.
+            print("[FluxCast WFD] Warning: --wfd-p2p-channel has no effect - "
+                  f"we ended up as {role}, not the Group Owner, so the sink "
+                  "picked the channel instead. Pair this with "
+                  "--wfd-go-intent 15 if you need the channel forced.")
 
         try:
             configure_ip(data_iface, peer_mac, role, physical_iface)

--- a/src/wfd/p2p/wpas.py
+++ b/src/wfd/p2p/wpas.py
@@ -1,0 +1,281 @@
+"""Direct wpa_supplicant P2P backend.
+
+An alternative to nm.py: instead of asking NetworkManager to bring up the
+P2P link, this module talks to wpa_supplicant's own D-Bus P2PDevice
+interface directly (Find, Connect, GroupStarted). NetworkManager is never
+asked to manage the connection, so it stays out of the way entirely.
+
+The payoff is control that NetworkManager's own API doesn't expose: we can
+set the WFD Device Info IE and the P2P operating channel ourselves, and
+watch each step of the negotiation up close when something needs debugging.
+
+See wpas_ip.py for everything that happens once a group exists - role
+detection and IP configuration live there to keep this file focused.
+
+Discovery, GO-intent handling, and device naming already have solid
+implementations elsewhere in this codebase (peers.py, device.py); this
+module's job is just to drive the connection itself, replacing
+_connect_peer / _wait_for_nm_activation from nm.py.
+"""
+
+import time
+from typing import Optional
+
+from ..config import WFDNotReady
+from ..constants import WFD_RTSP_PORT
+from .dbus import _gdbus_call, _object_paths, _variant_byte_array, _variant_string, _wfd_source_ie
+from .device import _p2p_device_iface_paths, _set_p2p_go_intent, _set_p2p_oper_channel
+from .peers import _default_wifi_interface
+from .wpas_ip import configure_ip, get_p2p_role, release_ip_config
+
+WPA_DEST = "fi.w1.wpa_supplicant1"
+WPA_IFACE = "fi.w1.wpa_supplicant1.Interface"
+WPA_P2P_IFACE = "fi.w1.wpa_supplicant1.Interface.P2PDevice"
+
+
+def _wpas_get_property(path: str, interface: str, prop: str) -> str:
+    """Properties.Get scoped to wpa_supplicant's own D-Bus service.
+
+    dbus.py's _nm_get_property is hardcoded to NetworkManager's D-Bus
+    destination, which makes sense for nm.py but not here: every object
+    path this module works with lives under wpa_supplicant's own service
+    (fi.w1.wpa_supplicant1), a completely different one. This small wrapper
+    just makes sure Peers/Ifname lookups actually ask the right service.
+    """
+    result = _gdbus_call([
+        "--dest", WPA_DEST,
+        "--object-path", path,
+        "--method", "org.freedesktop.DBus.Properties.Get",
+        interface,
+        prop,
+    ])
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def _wpas_find_peer_path(iface_path: str, mac: str) -> Optional[str]:
+    """Resolve a MAC address to its wpa_supplicant P2P peer object path.
+
+    wpa_supplicant names peer objects after their MAC address directly, e.g.
+    .../Peers/46d244e4372f for 46:D2:44:E4:37:2F (lowercase, colons
+    stripped), so we can match on the object path itself rather than doing
+    an extra Properties.Get round-trip per peer to read DeviceAddress.
+    """
+    peers_raw = _wpas_get_property(iface_path, WPA_P2P_IFACE, "Peers")
+    target = mac.lower().replace(":", "")
+    for peer_path in _object_paths(peers_raw):
+        suffix = peer_path.rsplit("/", 1)[-1].lower()
+        if suffix == target:
+            return peer_path
+    return None
+
+
+def _set_wfd_ies(rtsp_port: int) -> None:
+    """Tell wpa_supplicant our WFD Device Info subelement before it ever
+    negotiates or advertises anything.
+
+    WFDIEs is a property of the root fi.w1.wpa_supplicant1 service object
+    (global, not per-interface). The nm.py backend sets this correctly by
+    passing the same bytes (_wfd_source_ie, built from ie.py's "Source"
+    device-info bitmap) to NetworkManager as the 'wfd-ies' connection
+    setting, which NM then forwards to wpa_supplicant on our behalf. Since
+    this backend never goes through NetworkManager, nothing was writing
+    this property here, and wpa_supplicant would just keep whatever value
+    happened to be set beforehand - including, during testing, one that
+    declared us a Sink rather than a Source. Setting it ourselves here,
+    before Find/Connect, means this backend always advertises correctly and
+    never depends on any prior manual setup.
+    """
+    result = _gdbus_call([
+        "--dest", WPA_DEST,
+        "--object-path", "/fi/w1/wpa_supplicant1",
+        "--method", "org.freedesktop.DBus.Properties.Set",
+        WPA_DEST, "WFDIEs",
+        f"<{_variant_byte_array(_wfd_source_ie(rtsp_port))}>",
+    ], timeout=5.0)
+    if result.returncode != 0:
+        raise WFDNotReady(
+            f"Failed to set WFD Device Info IE: {(result.stderr or result.stdout).strip()}"
+        )
+
+
+def _find_peers(iface_path: str, timeout: int) -> None:
+    result = _gdbus_call([
+        "--dest", WPA_DEST,
+        "--object-path", iface_path,
+        "--method", f"{WPA_P2P_IFACE}.Find",
+        f"{{'Timeout': <int32 {timeout}>}}",
+    ], timeout=timeout + 3.0, privileged=True)
+    if result.returncode != 0:
+        raise WFDNotReady((result.stderr or result.stdout).strip())
+
+
+def _stop_find(iface_path: str) -> None:
+    try:
+        _gdbus_call([
+            "--dest", WPA_DEST,
+            "--object-path", iface_path,
+            "--method", f"{WPA_P2P_IFACE}.StopFind",
+        ], timeout=3.0, privileged=True)
+    except Exception:
+        pass
+
+
+def _wait_for_peer(iface_path: str, peer_mac: str, timeout: int = 20) -> str:
+    """Find() kicks off a background scan and returns almost immediately -
+    it doesn't block until discovery actually finishes. Polling for the
+    peer is more reliable than sleeping a fixed duration, since real-world
+    sinks can take well over ten seconds of air time to show up.
+    """
+    _find_peers(iface_path, timeout=timeout)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        peer_path = _wpas_find_peer_path(iface_path, peer_mac)
+        if peer_path:
+            _stop_find(iface_path)
+            return peer_path
+        time.sleep(2)
+    raise WFDNotReady(
+        f"Peer {peer_mac} not in wpa_supplicant's peer list after {timeout}s. "
+        "Confirm the sink is still in discoverable mode and re-run."
+    )
+
+
+def _wpas_connect(iface_path: str, peer_path: str, go_intent: int = 0,
+                   wps_method: str = "pbc") -> None:
+    args = (
+        "{"
+        f"'peer': <objectpath '{peer_path}'>, "
+        f"'wps_method': <'{wps_method}'>, "
+        f"'go_intent': <int32 {go_intent}>, "
+        "'persistent': <false>"
+        "}"
+    )
+    result = _gdbus_call([
+        "--dest", WPA_DEST,
+        "--object-path", iface_path,
+        "--method", f"{WPA_P2P_IFACE}.Connect",
+        args,
+    ], timeout=10.0, privileged=True)
+    if result.returncode != 0:
+        raise WFDNotReady((result.stderr or result.stdout).strip())
+
+
+def _list_wpas_interfaces() -> set[str]:
+    result = _gdbus_call([
+        "--dest", WPA_DEST,
+        "--object-path", "/fi/w1/wpa_supplicant1",
+        "--method", "org.freedesktop.DBus.Properties.Get",
+        WPA_DEST, "Interfaces",
+    ])
+    if result.returncode != 0:
+        return set()
+    return set(_object_paths(result.stdout))
+
+
+def _wait_for_group_interface(before: set[str], timeout: float = 40.0) -> str:
+    """Detect the new wpa_supplicant Interface object GO Negotiation creates,
+    then read its Ifname to get the real OS network interface name.
+
+    wpa_supplicant also fires a GroupStarted signal carrying the interface
+    object directly, which would be a more direct way to get this - but
+    this module drives D-Bus via synchronous `gdbus call` subprocesses
+    throughout (see dbus.py), and parsing `gdbus monitor` output reliably
+    for a single signal is more fragile than polling the same
+    Properties.Get calls used everywhere else here. Worth revisiting with a
+    proper dbus_next signal subscription (already a project dependency) if
+    this polling ever proves too slow in practice.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        new_paths = _list_wpas_interfaces() - before
+        for path in new_paths:
+            ifname_raw = _wpas_get_property(path, WPA_IFACE, "Ifname")
+            ifname = _variant_string(ifname_raw)
+            if ifname:
+                return ifname
+        time.sleep(0.5)
+    raise WFDNotReady(
+        "Timed out waiting for wpa_supplicant to form the P2P group "
+        f"(no new data interface after {timeout:.0f}s)."
+    )
+
+
+def connect_via_wpa_supplicant(interface: Optional[str], peer_mac: str,
+                                go_intent: int = 0,
+                                rtsp_port: int = WFD_RTSP_PORT,
+                                p2p_channel: Optional[int] = None) -> str:
+    """Full connect flow bypassing NetworkManager. Returns the data interface
+    name once it has a real IP address, ready for the RTSP server to use.
+    """
+    paths = _p2p_device_iface_paths(interface)
+    if not paths:
+        raise WFDNotReady("wpa_supplicant P2P interface not found.")
+    iface_path = paths[0]
+    physical_iface = interface or _default_wifi_interface()
+
+    # Must happen before Find/Connect - see _set_wfd_ies's docstring.
+    _set_wfd_ies(rtsp_port)
+
+    if p2p_channel is not None:
+        _set_p2p_oper_channel(interface, p2p_channel)
+
+    # GO intent only matters for GO Negotiation (Connect()), so it's set
+    # right before that call rather than up here alongside discovery.
+    # Setting it earlier raced wpa_supplicant's P2P state machine: Find()
+    # would report success, but Peers stayed empty.
+    previous_intent = None
+    try:
+        peer_path = _wait_for_peer(iface_path, peer_mac)
+
+        previous_intent = _set_p2p_go_intent(interface, go_intent)
+        interfaces_before = _list_wpas_interfaces()
+        print(f"[FluxCast WFD] Connecting to {peer_mac} directly via wpa_supplicant "
+              "(NetworkManager not involved in this step)...")
+        _wpas_connect(iface_path, peer_path, go_intent=go_intent)
+
+        data_iface = _wait_for_group_interface(interfaces_before)
+        role = get_p2p_role(data_iface)
+        print(f"[FluxCast WFD] P2P group formed on {data_iface}; our role: {role}")
+
+        try:
+            configure_ip(data_iface, peer_mac, role, physical_iface)
+        except Exception:
+            # session.py's cleanup (release_wpa_supplicant_connection) only
+            # runs once this function successfully returns a value, so a
+            # failure here needs to clean up after itself - otherwise a
+            # leftover dnsmasq instance can port-conflict with the next run.
+            release_ip_config(data_iface)
+            raise
+
+        print(f"[FluxCast WFD] {data_iface} is up and IP-configured. "
+              "Handing off to the RTSP server.")
+        return data_iface
+    finally:
+        if previous_intent is not None:
+            _set_p2p_go_intent(interface, previous_intent, restoring=True)
+
+
+def release_wpa_supplicant_connection(interface: Optional[str], data_iface: str) -> None:
+    """Undo connect_via_wpa_supplicant(): release the IP configuration, tear
+    down the P2P group, and hand the data interface back to NetworkManager.
+
+    Mirrors nm.py's _disconnect_device, but for the raw-supplicant path -
+    there is no NetworkManager active connection to deactivate here since
+    NM was never involved in bringing this link up.
+    """
+    release_ip_config(data_iface)
+
+    paths = _p2p_device_iface_paths(interface)
+    if paths:
+        try:
+            _gdbus_call([
+                "--dest", WPA_DEST,
+                "--object-path", paths[0],
+                "--method", f"{WPA_P2P_IFACE}.GroupRemove",
+                f"'{data_iface}'",
+            ], timeout=10.0, privileged=True)
+            print("[FluxCast WFD] wpa_supplicant P2P group removed.")
+        except Exception as exc:
+            print(f"[FluxCast WFD] Warning: GroupRemove failed: {exc}")

--- a/src/wfd/p2p/wpas_ip.py
+++ b/src/wfd/p2p/wpas_ip.py
@@ -162,8 +162,14 @@ def _run_as_go(iface: str, peer_mac: str, physical_iface: Optional[str] = None,
     if physical_iface:
         dnsmasq_cmd.append(f"--interface={physical_iface}")
     dnsmasq_cmd += [
+        # --dhcp-host sets the wfdsink tag on the sink's MAC. The range
+        # must then require that tag (tag:) to actually restrict who's
+        # eligible for it - set:wfdsink here would instead apply the tag
+        # to whoever happens to take an address, which doesn't restrict
+        # anything and would turn physical_iface into an open DHCP server
+        # for every other device on that network.
         f"--dhcp-host={peer_mac},set:wfdsink",
-        f"--dhcp-range=set:wfdsink,{WFD_P2P_SUBNET}.2,{WFD_P2P_SUBNET}.254,255.255.255.0,1h",
+        f"--dhcp-range=tag:wfdsink,{WFD_P2P_SUBNET}.2,{WFD_P2P_SUBNET}.254,255.255.255.0,1h",
         f"--dhcp-leasefile={lease_file}",
         "--port=0",  # DHCP only, no DNS service on this interface
         "--no-resolv", "--no-hosts",

--- a/src/wfd/p2p/wpas_ip.py
+++ b/src/wfd/p2p/wpas_ip.py
@@ -1,0 +1,353 @@
+"""IP-layer configuration for the raw-wpa_supplicant P2P backend (wpas.py).
+
+Split out of wpas.py to keep each file focused. This module picks up once a
+P2P group already exists: which role we ended up with, and how to get a
+working IP on the resulting interface for that role.
+
+The P2P spec doesn't guarantee who becomes Group Owner - it's negotiated,
+and plenty of real-world WFD sinks expect to end up as GO themselves while
+the source acts as client. When the roles land the other way around (we're
+GO, the sink is client), a plain DHCP client on our side has nothing to
+talk to, and NetworkManager's own path correctly self-assigns an address
+with no gateway rather than pretending otherwise.
+
+So this module detects the actual role (get_p2p_role) and branches: as GO,
+serve DHCP to the sink ourselves (_run_as_go: static IP + dnsmasq); as
+client, run a real DHCP client (_run_dhcp_client) against the sink's own
+DHCP server.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import time
+from typing import Optional
+
+from ..config import WFDNotReady
+
+# Standard Wi-Fi Direct convention subnet (matches diagnostics.py's own
+# "P2P subnet" check, and Android's own WiFi Direct GO addressing) - used
+# only when we end up as GO ourselves.
+WFD_P2P_SUBNET = "192.168.49"
+
+_go_dnsmasq_lease_file: Optional[str] = None
+
+
+def _sudo_run(args: list[str], timeout: float) -> subprocess.CompletedProcess[str]:
+    """Like subprocess.run, but under sudo. This whole backend runs as the
+    calling user (main.py is never invoked with sudo itself) - binding a DHCP
+    client/server to a raw interface and touching routes both need root.
+    sudo's password prompt goes straight to the controlling terminal, so this
+    stays interactive if the session's cached sudo timestamp has expired.
+    """
+    return subprocess.run(["sudo", *args], capture_output=True, text=True, timeout=timeout)
+
+
+def get_p2p_role(iface: str) -> str:
+    """Returns 'P2P-GO', 'P2P-client', or 'unknown'."""
+    result = subprocess.run(["iw", "dev", iface, "info"],
+                             capture_output=True, text=True, timeout=5.0)
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line.startswith("type"):
+            return line.partition(" ")[2].strip()
+    return "unknown"
+
+
+def configure_ip(iface: str, peer_mac: str, role: str,
+                  physical_iface: Optional[str] = None) -> None:
+    """Bring up a working IP on iface for the given P2P role.
+
+    physical_iface (e.g. wlp0s20f3) is only used in the GO branch - some
+    driver/firmware combinations demultiplex the projector's broadcast
+    DHCPDISCOVER onto the physical radio instead of the P2P virtual
+    interface, so dnsmasq needs to listen there too (see _run_as_go).
+    """
+    if role == "P2P-GO":
+        _run_as_go(iface, peer_mac, physical_iface)
+    else:
+        # Genuine P2P-client role: a real DHCP server (the projector,
+        # correctly acting as GO) should be on the other end. Deliberately
+        # not marking the interface NM-unmanaged here - telling NM to
+        # release a device it just discovered (rather than never managing
+        # it via a static conf.d rule matched at interface-creation time)
+        # was observed bouncing the interface down/up ("carrier lost"
+        # mid-DHCP on an earlier run).
+        _run_dhcp_client(iface)
+
+
+def release_ip_config(iface: str) -> None:
+    """Undo configure_ip(): stop whatever we started (dnsmasq or a DHCP
+    client) and hand the interface back to NetworkManager.
+    """
+    _stop_go_dnsmasq()  # no-op if we were P2P-client, not GO
+
+    release_cmd = None
+    if shutil.which("dhcpcd"):
+        release_cmd = ["dhcpcd", "-k", iface]
+    elif shutil.which("dhclient"):
+        release_cmd = ["dhclient", "-r", iface]
+    if release_cmd:
+        try:
+            _sudo_run(release_cmd, timeout=10.0)
+        except Exception as exc:
+            print(f"[FluxCast WFD] Warning: DHCP release failed on {iface}: {exc}")
+
+    try:
+        _sudo_run(["nmcli", "device", "set", iface, "managed", "yes"], timeout=5.0)
+    except Exception as exc:
+        print(f"[FluxCast WFD] Warning: could not restore NM management of {iface}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# GO role: we host DHCP for the projector.
+# ---------------------------------------------------------------------------
+
+def _run_as_go(iface: str, peer_mac: str, physical_iface: Optional[str] = None,
+                timeout: float = 25.0) -> None:
+    global _go_dnsmasq_lease_file
+    gateway_ip = f"{WFD_P2P_SUBNET}.1"
+    print(f"[FluxCast WFD] We are P2P Group Owner; assigning ourselves {gateway_ip}/24 "
+          "and serving DHCP to the projector...")
+
+    # Unlike the client-role path (see configure_ip's comment on why it
+    # skips this), marking the interface unmanaged here protects against
+    # NetworkManager auto-detecting the new P2P interface and activating its
+    # own "shared" mode (self-assign + its own dnsmasq) on it concurrently,
+    # which would conflict with the dnsmasq instance we're about to start.
+    mark_unmanaged(iface)
+    _sudo_run(["ip", "addr", "flush", "dev", iface], timeout=5.0)
+    add = _sudo_run(["ip", "addr", "add", f"{gateway_ip}/24", "dev", iface], timeout=5.0)
+    if add.returncode != 0:
+        raise WFDNotReady(
+            f"Could not assign {gateway_ip}/24 to {iface}: "
+            f"{(add.stderr or add.stdout).strip()}"
+        )
+    _sudo_run(["ip", "link", "set", iface, "up"], timeout=5.0)
+    if not _wait_for_link_running(iface, timeout=10.0):
+        print(f"[FluxCast WFD] Warning: {iface} never reported LOWER_UP "
+              "(carrier) - proceeding anyway, but this may be why dnsmasq "
+              "fails to bind.")
+
+    if not shutil.which("dnsmasq"):
+        raise WFDNotReady("dnsmasq not found - needed to serve DHCP while we're P2P GO.")
+
+    lease_file = f"/tmp/fluxcast-dnsmasq-{iface}.leases"
+    try:
+        os.remove(lease_file)
+    except FileNotFoundError:
+        pass
+    _go_dnsmasq_lease_file = lease_file
+    dnsmasq_log = f"/tmp/fluxcast-dnsmasq-{iface}.log"
+
+    # dnsmasq is scoped by the sink's MAC address (--dhcp-host + a tagged
+    # --dhcp-range) rather than by interface. This matters for two reasons:
+    #
+    # - Some driver/firmware combinations deliver the sink's DHCPDISCOVER
+    #   broadcast on the physical radio (physical_iface) rather than the
+    #   P2P virtual interface, even though the P2P link is what's actually
+    #   carrying it - so dnsmasq needs to listen on both.
+    # - physical_iface also carries our regular office Wi-Fi traffic, so
+    #   serving DHCP there unconditionally would make this laptop a rogue
+    #   DHCP server for every other device on that network. Scoping by MAC
+    #   means we only ever answer this one specific sink, on whichever
+    #   interface its broadcast happens to land on.
+    #
+    # Note that listing an interface explicitly disables --bind-dynamic's
+    # usual auto-detection for any *other* interface, so once physical_iface
+    # is involved at all, both interfaces need to be named explicitly.
+    dnsmasq_cmd = ["sudo", "dnsmasq", "--no-daemon", "--bind-dynamic",
+                   f"--interface={iface}"]
+    if physical_iface:
+        dnsmasq_cmd.append(f"--interface={physical_iface}")
+    dnsmasq_cmd += [
+        f"--dhcp-host={peer_mac},set:wfdsink",
+        f"--dhcp-range=set:wfdsink,{WFD_P2P_SUBNET}.2,{WFD_P2P_SUBNET}.254,255.255.255.0,1h",
+        f"--dhcp-leasefile={lease_file}",
+        "--port=0",  # DHCP only, no DNS service on this interface
+        "--no-resolv", "--no-hosts",
+    ]
+    print(f"[FluxCast WFD] Starting dnsmasq on {iface}...")
+    with open(dnsmasq_log, "wb") as log_fp:
+        # We don't track this via the returned Popen's .pid: depending on
+        # sudoers pty settings, sudo may exec-replace itself (pid stays the
+        # same) or fork-and-monitor (it doesn't), so the pid isn't reliably
+        # dnsmasq's own. release_ip_config matches on the lease-file path
+        # instead (see _stop_go_dnsmasq) - that's also why cleaning up after
+        # a failed run matters: a lingering instance would otherwise
+        # port-conflict with the next one.
+        subprocess.Popen(dnsmasq_cmd, stdout=log_fp, stderr=subprocess.STDOUT)
+
+    peer_ip = _wait_for_lease(lease_file, peer_mac, timeout)
+    if not peer_ip:
+        try:
+            with open(dnsmasq_log) as f:
+                print(f"[FluxCast WFD] dnsmasq log:\n{f.read()}")
+        except FileNotFoundError:
+            pass
+        raise WFDNotReady(
+            f"No DHCP lease handed out to {peer_mac} after {timeout:.0f}s - "
+            "the projector may not be attempting DHCP client behaviour "
+            "(some WFD sink firmware assumes it will always be GO and may "
+            "not have real client-mode network logic to fall back on)."
+        )
+    print(f"[FluxCast WFD] Projector leased {peer_ip}. Seeding ARP entry...")
+    subprocess.run(["ping", "-c", "1", "-W", "2", "-I", iface, peer_ip],
+                    capture_output=True, text=True, timeout=5.0)
+
+
+def _wait_for_link_running(iface: str, timeout: float) -> bool:
+    """`ip link set up` returning doesn't guarantee the kernel/driver has
+    actually brought up carrier (LOWER_UP) on a freshly created P2P virtual
+    interface yet - dnsmasq can fail to bind if it starts too early. Poll
+    for LOWER_UP instead of assuming the interface is ready immediately.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(["ip", "link", "show", iface],
+                                 capture_output=True, text=True, timeout=3.0)
+        if "LOWER_UP" in result.stdout:
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def _wait_for_lease(lease_file: str, peer_mac: str, timeout: float) -> Optional[str]:
+    target = peer_mac.lower()
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with open(lease_file) as f:
+                for line in f:
+                    # dnsmasq.leases format: <expiry> <mac> <ip> <hostname> <client-id>
+                    parts = line.split()
+                    if len(parts) >= 3 and parts[1].lower() == target:
+                        return parts[2]
+        except FileNotFoundError:
+            pass
+        time.sleep(1)
+    return None
+
+
+def _stop_go_dnsmasq() -> None:
+    global _go_dnsmasq_lease_file
+    if _go_dnsmasq_lease_file is None:
+        return
+    try:
+        _sudo_run(["pkill", "-f", f"dnsmasq.*{_go_dnsmasq_lease_file}"], timeout=5.0)
+    except Exception as exc:
+        print(f"[FluxCast WFD] Warning: could not stop dnsmasq: {exc}")
+    _go_dnsmasq_lease_file = None
+
+
+# ---------------------------------------------------------------------------
+# Client role: the projector hosts DHCP, we request a lease from it.
+# ---------------------------------------------------------------------------
+
+def _run_dhcp_client(iface: str, timeout: float = 20.0) -> None:
+    print(f"[FluxCast WFD] Requesting DHCP lease on {iface} directly (bypassing NM)...")
+    if shutil.which("dhcpcd"):
+        # No -1 (one-shot): a one-shot run exits immediately once configured,
+        # leaving nothing for the later `dhcpcd -U` call (_seed_peer_arp_entry)
+        # to query. Running persistently keeps a daemon alive to ask about
+        # the lease's gateway afterward. It also means this call blocks in
+        # the foreground until the lease actually completes (that's what
+        # triggers its fork-to-background) rather than returning early, so
+        # it needs the full timeout budget, not a short launch-only one.
+        # -G: never install a default route from this lease. This link is to
+        # an external, untrusted P2P peer (the sink) - it must never become
+        # the machine's route to the internet/office LAN.
+        result = _sudo_run(["dhcpcd", "-G", iface], timeout=timeout + 10.0)
+        if result.returncode != 0:
+            raise WFDNotReady(
+                f"dhcpcd failed to start on {iface}: {(result.stderr or result.stdout).strip()}"
+            )
+        if not _wait_for_ipv4(iface, timeout):
+            raise WFDNotReady(f"No IPv4 address on {iface} after {timeout:.0f}s.")
+    elif shutil.which("dhclient"):
+        # dhclient has no no-default-route flag; strip any route it installs
+        # immediately after. One-shot mode is fine here since
+        # _seed_peer_arp_entry only tries dhcpcd -U.
+        result = _sudo_run(["dhclient", "-1", "-v", iface], timeout=timeout + 5.0)
+        if result.returncode != 0:
+            raise WFDNotReady(
+                f"dhclient failed on {iface}: {(result.stderr or result.stdout).strip()}"
+            )
+    else:
+        raise WFDNotReady(
+            "No DHCP client found (checked dhcpcd, dhclient). "
+            "The P2P data interface needs its own DHCP client since "
+            "NetworkManager is not managing it."
+        )
+    _seed_peer_arp_entry(iface)
+    _strip_default_route(iface)
+
+
+def _wait_for_ipv4(iface: str, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(["ip", "-4", "-br", "addr", "show", "dev", iface],
+                                 capture_output=True, text=True, timeout=3.0)
+        if result.returncode == 0 and re.search(r"\d+\.\d+\.\d+\.\d+/\d+", result.stdout):
+            return True
+        time.sleep(1)
+    return False
+
+
+def _seed_peer_arp_entry(iface: str) -> None:
+    """Ping the DHCP-lease gateway once so the kernel resolves its ARP entry.
+
+    The projector is the DHCP server here (it's the P2P Group Owner), so the
+    lease's gateway/router option IS the projector's IP - but -G means it
+    was never installed as a route, so it can't be read back from `ip route`.
+    `dhcpcd -U` dumps the raw lease options regardless of -G. Without this,
+    FluxCast's active RTSP probe (probe.py -> addressing.py) finds an empty
+    ARP table and never discovers the sink's address, because that lookup
+    only reads the existing neighbour cache - it never triggers resolution
+    itself. This ping is what NetworkManager's own connectivity checks did
+    for free on the nm.py path.
+    """
+    if not shutil.which("dhcpcd"):
+        return
+    result = _sudo_run(["dhcpcd", "-U", iface], timeout=5.0)
+    if result.returncode != 0:
+        return
+    gateway = next(
+        (line.partition("=")[2].strip().strip("'\"")
+         for line in result.stdout.splitlines() if line.startswith("routers=")),
+        None,
+    )
+    if not gateway:
+        print("[FluxCast WFD] Warning: no gateway in DHCP lease; "
+              "active RTSP probe may not find the sink's IP.")
+        return
+    print(f"[FluxCast WFD] Seeding ARP entry for sink at {gateway}...")
+    subprocess.run(["ping", "-c", "1", "-W", "2", "-I", iface, gateway],
+                    capture_output=True, text=True, timeout=5.0)
+
+
+def _strip_default_route(iface: str) -> None:
+    """Defense in depth on top of dhcpcd -G: remove any default route the
+    lease installed on this interface. The peer is an external, untrusted
+    device - it must never become this machine's route to the internet or
+    the office LAN, regardless of which DHCP client handled the lease.
+    """
+    try:
+        _sudo_run(["ip", "route", "del", "default", "dev", iface], timeout=5.0)
+    except Exception:
+        pass
+
+
+def mark_unmanaged(iface: str) -> None:
+    """Keep NetworkManager off the interface we're about to hand-configure.
+
+    Used in the GO branch (see _run_as_go); the client branch deliberately
+    skips this - see configure_ip's comment for why. A static conf.d
+    unmanaged-devices rule would be a cleaner long-term replacement for
+    this reactive nmcli call, if that turns out to matter in practice.
+    """
+    try:
+        _sudo_run(["nmcli", "device", "set", iface, "managed", "no"], timeout=5.0)
+    except Exception as exc:
+        print(f"[FluxCast WFD] Warning: could not mark {iface} unmanaged: {exc}")

--- a/src/wfd/session.py
+++ b/src/wfd/session.py
@@ -14,6 +14,7 @@ from .p2p.nm import (
     _nm_p2p_device_path, _wait_for_nm_activation,
 )
 from .p2p.peers import _scan_and_select
+from .p2p.wpas import connect_via_wpa_supplicant, release_wpa_supplicant_connection
 from .probe import _active_rtsp_probe
 from .rtsp.rtsp_server import WFDRTSPServer
 
@@ -125,6 +126,8 @@ def start_experimental_backend(args) -> None:
     uibc_firewall_opened = False
     active_path = ""
     previous_go_intent = None
+    p2p_backend = getattr(args, "wfd_p2p_backend", "nm")
+    wpas_data_iface = None
     try:
         # Clear stale P2P device state from previous runs before new activation.
         try:
@@ -132,17 +135,28 @@ def start_experimental_backend(args) -> None:
         except Exception:
             pass
         rtsp.start()
-        # Lower our GO intent before negotiation so the TV becomes the group
-        # owner; most Miracast sinks only start the RTSP session in that role.
-        previous_go_intent = _set_p2p_go_intent(
-            args.wfd_interface, getattr(args, "wfd_go_intent", 0)
-        )
-        active_path = _connect_peer(
-            device_path,
-            peer,
-            rtsp_port=rtsp_port,
-        )
-        _wait_for_nm_activation(active_path)
+        if p2p_backend == "wpas":
+            # Bypasses NetworkManager's AddAndActivateConnection2 entirely -
+            # see wpas.py's module docstring for why. connect_via_wpa_supplicant
+            # handles GO-intent lowering internally, so it isn't done here.
+            wpas_data_iface = connect_via_wpa_supplicant(
+                args.wfd_interface, peer.address,
+                go_intent=getattr(args, "wfd_go_intent", 0),
+                rtsp_port=rtsp_port,
+                p2p_channel=getattr(args, "wfd_p2p_channel", None),
+            )
+        else:
+            # Lower our GO intent before negotiation so the TV becomes the group
+            # owner; most Miracast sinks only start the RTSP session in that role.
+            previous_go_intent = _set_p2p_go_intent(
+                args.wfd_interface, getattr(args, "wfd_go_intent", 0)
+            )
+            active_path = _connect_peer(
+                device_path,
+                peer,
+                rtsp_port=rtsp_port,
+            )
+            _wait_for_nm_activation(active_path)
 
         if not getattr(args, "wfd_no_firewall", False):
             firewall_opened = _open_wfd_firewall_port(rtsp_port)
@@ -175,6 +189,13 @@ def start_experimental_backend(args) -> None:
         if active_path:
             _cleanup_step("connection deactivate",
                           lambda: _deactivate_connection(active_path))
+        if wpas_data_iface:
+            _cleanup_step(
+                "wpa_supplicant connection release",
+                lambda: release_wpa_supplicant_connection(
+                    args.wfd_interface, wpas_data_iface
+                ),
+            )
         _cleanup_step("P2P device disconnect", lambda: _disconnect_device(device_path))
         if previous_go_intent is not None:
             _cleanup_step(

--- a/tests/test_wpas.py
+++ b/tests/test_wpas.py
@@ -1,0 +1,128 @@
+import os
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from wfd.config import WFDNotReady  # noqa: E402
+from wfd.ie import _wfd_ie_device_info  # noqa: E402
+from wfd.p2p import dbus, device, wpas_ip  # noqa: E402
+from wfd.p2p.dbus import _wfd_source_ie  # noqa: E402
+
+
+PEER_MAC = "46:d2:44:e4:37:2f"
+
+
+def _completed(stdout="", returncode=0, stderr=""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class WfdDeviceInfoIeTest(unittest.TestCase):
+    """The Device Info subelement's device-type bits (0-1 of the info
+    bitmap) declare our WFD role to the peer. Getting this wrong - as an
+    earlier build of the wpas backend briefly did, by inheriting whatever a
+    manual wpa_cli command had last set - means advertising ourselves as a
+    Sink while negotiating for a client role, a contradiction a WFD-aware
+    peer has no correct way to honor.
+    """
+
+    def test_declares_source_not_sink(self):
+        ie = _wfd_ie_device_info(7236)
+        info_bitmap = (ie[3] << 8) | ie[4]
+        device_type = info_bitmap & 0b11
+        self.assertEqual(device_type, 0, "device-type bits must be 00 (Source)")
+
+    def test_encodes_rtsp_port_and_length(self):
+        ie = _wfd_ie_device_info(7236)
+        self.assertEqual(ie[0:3], bytes([0x00, 0x00, 0x06]))  # subelem 0, length 6
+        port = (ie[5] << 8) | ie[6]
+        self.assertEqual(port, 7236)
+
+    def test_rejects_out_of_range_port(self):
+        with self.assertRaises(WFDNotReady):
+            _wfd_source_ie(0)
+        with self.assertRaises(WFDNotReady):
+            _wfd_source_ie(70000)
+
+
+class OperChannelTest(unittest.TestCase):
+    """--wfd-p2p-channel forces the operating channel via the same
+    P2PDeviceConfig struct as GOIntent, using reg_class 81 (2.4GHz,
+    channels 1-13).
+    """
+
+    def test_sends_the_requested_channel_and_reg_class(self):
+        with mock.patch.object(device, "_p2p_device_iface_paths",
+                                return_value=["/fi/w1/wpa_supplicant1/Interfaces/1"]), \
+             mock.patch.object(device, "_gdbus_call", return_value=_completed()) as call:
+            ok = device._set_p2p_oper_channel("wlan0", 6)
+
+        self.assertTrue(ok)
+        args = call.call_args[0][0]
+        payload = args[-1]
+        self.assertIn("'OperChannel': <uint32 6>", payload)
+        self.assertIn("'OperRegClass': <uint32 81>", payload)
+
+    def test_returns_false_without_a_p2p_interface(self):
+        with mock.patch.object(device, "_p2p_device_iface_paths", return_value=[]):
+            ok = device._set_p2p_oper_channel("wlan0", 6)
+        self.assertFalse(ok)
+
+
+class GdbusCallTimeoutTest(unittest.TestCase):
+    """A stuck Find/Connect call should surface as WFDNotReady, not a raw
+    subprocess.TimeoutExpired traceback.
+    """
+
+    def test_privileged_call_timeout_becomes_wfd_not_ready(self):
+        with mock.patch.object(dbus, "_run",
+                                side_effect=subprocess.TimeoutExpired(cmd="gdbus", timeout=5.0)):
+            with self.assertRaises(WFDNotReady):
+                dbus._gdbus_call(
+                    ["--dest", "fi.w1.wpa_supplicant1", "--method",
+                     "fi.w1.wpa_supplicant1.Interface.P2PDevice.Connect"],
+                    privileged=True,
+                )
+
+    def test_unprivileged_call_timeout_becomes_wfd_not_ready(self):
+        with mock.patch.object(dbus, "_run",
+                                side_effect=subprocess.TimeoutExpired(cmd="gdbus", timeout=5.0)):
+            with self.assertRaises(WFDNotReady):
+                dbus._gdbus_call(["--dest", "fi.w1.wpa_supplicant1"])
+
+
+class RunAsGoDnsmasqCommandTest(unittest.TestCase):
+    """Regression test for a real bug caught in review: --dhcp-range needs
+    tag:wfdsink, not set:wfdsink. set: labels whoever takes an address from
+    the range - it doesn't restrict who's eligible for it. Combined with
+    also listening on the physical interface, that turned dnsmasq into an
+    open DHCP server for every device on that network, not just the sink.
+    """
+
+    def test_dhcp_range_requires_the_wfdsink_tag(self):
+        with mock.patch.object(wpas_ip, "mark_unmanaged"), \
+             mock.patch.object(wpas_ip, "_sudo_run", return_value=_completed()), \
+             mock.patch.object(wpas_ip, "_wait_for_link_running", return_value=True), \
+             mock.patch.object(wpas_ip.shutil, "which", return_value="/usr/sbin/dnsmasq"), \
+             mock.patch.object(wpas_ip.os, "remove"), \
+             mock.patch("builtins.open", mock.mock_open()), \
+             mock.patch.object(wpas_ip.subprocess, "Popen") as popen, \
+             mock.patch.object(wpas_ip.subprocess, "run", return_value=_completed()), \
+             mock.patch.object(wpas_ip, "_wait_for_lease", return_value="192.168.49.5"):
+            wpas_ip._run_as_go("p2p-wlan0-5", PEER_MAC, physical_iface="wlan0")
+
+        dnsmasq_cmd = popen.call_args[0][0]
+        range_arg = next(a for a in dnsmasq_cmd if a.startswith("--dhcp-range="))
+        host_arg = next(a for a in dnsmasq_cmd if a.startswith("--dhcp-host="))
+
+        self.assertIn("tag:wfdsink", range_arg)
+        self.assertNotIn("set:wfdsink", range_arg)
+        self.assertIn("set:wfdsink", host_arg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- New opt-in P2P backend, `--wfd-p2p-backend wpas`, that talks to wpa_supplicant's own D-Bus interface directly instead of going through NetworkManager. The default (`nm`) is untouched - this is purely additive.
- It gives control that NetworkManager's own P2P API doesn't expose: the WFD Device Info IE content, GO-intent timing, and the P2P operating channel.
- New `--wfd-p2p-channel {1,6,11}` flag (only meaningful with `wpas`) forces the P2P group onto a 2.4GHz channel. Some WFD sinks only support Wi-Fi Direct on 2.4GHz - if the driver picks 5GHz on its own, GO Negotiation completes fine, but the sink never actually shows up at the 802.11 level.
- Small widening of `meta/zz-dev.fluxcast.wpa-supplicant.conf`: the four P2PDevice actions the new backend needs (`Find`/`Connect`/`StopFind`/`GroupRemove`) are now also granted to the `netdev` group, not just root - the same group wpa_supplicant's own control socket is already scoped to. `_gdbus_call()` tries unprivileged first and only falls back to `sudo` on an actual `AccessDenied`, so this doesn't change behavior for anyone already running as root.

## Why

I ran into a Miracast/WFD sink where the NetworkManager P2P path kept failing to configure IP addressing correctly, and NetworkManager's own API gave me no visibility into what was actually happening during negotiation. Talking to wpa_supplicant directly let me watch (and control) each step, which surfaced two real, fixable issues along the way: the WFD IE wasn't declaring the correct device role on this path, and this particular Wi-Fi chipset only forms a usable P2P group on 2.4GHz with some sinks. Both are fixed here, and the new backend should be generally useful for anyone debugging a stubborn P2P connection, not just my specific case.

## What this doesn't fix

The `netdev` policy change only covers P2P negotiation. `wpas_ip.py`'s IP-layer work (`ip`, `dnsmasq`, `dhcpcd`) is raw shell commands, not D-Bus, so it still needs real root regardless of group membership - a `netdev`-only user without sudo can discover and negotiate but can't complete a connection end-to-end today. Closing that properly would mean a small privileged helper (a setuid binary, or a tiny root-owned daemon this process talks to over a socket). I kept that out of this PR to keep it focused, but happy to take a swing at it as a follow-up if that's something you'd want.

## Testing

Tested against a real WFD sink over several sessions - GO Negotiation, WPS provisioning, and 802.11 association all complete correctly through this backend, and the channel-forcing behavior does what it says (checked via `iw station dump` and wpa_supplicant's own debug log). The specific sink I tested against turned out to have its own unrelated compatibility issue after association - a client-side WPS quirk, not anything on FluxCast's side - so I never got a full end-to-end cast against that particular unit. I'll file that separately against wpa_supplicant/hostap upstream, since it's not something this project can fix; mentioning it here mostly in case anyone else runs into the same wall.

Thanks for maintaining this project - happy to adjust anything here.
