### PR TITLE
fix: bound HLS playlist with delete_segments (fixes #110)

### DIFF
--- a/src/capture/capture.py
+++ b/src/capture/capture.py
@@ -289,7 +289,7 @@ def _start_capture_wf_recorder(
         "-p", "tune=zerolatency",
         "-p", "hls_time=1",
         "-p", "hls_list_size=3",
-        "-p", "hls_flags=append_list",
+        "-p", "hls_flags=delete_segments",
         "-p", "pix_fmt=yuv420p",
         "-p", "profile=main",
         "-f", "/tmp/fluxcast/stream.m3u8",
@@ -548,7 +548,7 @@ def _start_capture_x11grab(
         "-f", "hls",
         "-hls_time", "2",
         "-hls_list_size", "6",
-        "-hls_flags", "append_list",
+        "-hls_flags", "delete_segments",
         "-hls_segment_filename", os.path.join(hls_dir, "stream%d.ts"),
         os.path.join(hls_dir, "stream.m3u8"),
     ]


### PR DESCRIPTION
## Problem
Fixes #110 — long DLNA/Cast sessions fill /tmp (tmpfs) because HLS segments are never deleted.

Both capture paths build an HLS manifest with `hls_flags=append_list`:
- `src/capture/capture.py:292` (wf-recorder Wayland path, `hls_list_size=3` set but ignored)
- `src/capture/capture.py:551` (X11 x11grab path, `hls_list_size=6` set but ignored)

## Root cause
`append_list` disables FFmpeg sliding-window deletion entirely — segments append forever, producing EVENT-style growing playlist. This contradicts the Cast path which sends `STREAM_TYPE_LIVE` in `src/cast/cast.py`, and wastes parse cost on every manifest refresh. Receivers that validate strictly can choke, matching vendor-specific reliability reports.

## Fix
- `src/capture/capture.py:292`: `hls_flags=append_list` → `hls_flags=delete_segments`
- `src/capture/capture.py:551`: `-hls_flags append_list` → `-hls_flags delete_segments`

Existing `hls_time` / `hls_list_size` values now take effect as bounded sliding windows (3 and 6 segments), segment files roll off disk, no EXT-X-PLAYLIST-TYPE tag is emitted so playlist semantics match LIVE.

Minimal 2-line diff, no refactoring.

## Verification
- Repro: `grep append_list src/capture/capture.py` showed 2 hits before, 0 after; `delete_segments` 0 before, 2 after.
- `python3 -m py_compile src/capture/capture.py` → OK
- `python3 -m unittest tests.test_wf_recorder -v` → 4 tests OK
- `git diff --stat` → 1 file, 2 insertions, 2 deletions