### PR TITLE
Accept wfd-aosp-pmt-pid, wfd-uibc and wfd-go-intent in the tray config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ python3 src/main.py --protocol wfd --wfd-capture-backend wf-recorder
 python3 src/main.py --protocol wfd --wfd-capture-backend x11grab
 ```
 
+Android-based sinks (TV boxes, projectors) that connect but stay on a black
+screen:
+
+```bash
+python3 src/main.py --protocol wfd --wfd-aosp-pmt-pid
+```
+
 WFD P2P connection troubleshooting - talk to wpa_supplicant directly instead
 of going through NetworkManager, and optionally pin the group to a 2.4GHz
 channel for sinks that don't support Wi-Fi Direct on 5GHz:

--- a/documentation/DOCUMENTATION.md
+++ b/documentation/DOCUMENTATION.md
@@ -61,6 +61,7 @@ python3 src/main.py --protocol cast
 - `--wfd-capture-backend auto|portal|wf-recorder|x11grab|gst-x11`
   - `auto` uses `portal` first on KDE/GNOME Wayland, then `wf-recorder` fallback.
 - `--wfd-latency-log [PATH]`
+- `--wfd-aosp-pmt-pid` write MPEG-TS tables the way Android (AOSP) sinks expect them
 - `--wfd-no-audio`
 - `--wfd-audio-device DEVICE`
 - `--wfd-rtsp-port PORT`
@@ -129,6 +130,7 @@ sections also accept `host`, `port`, `discover-timeout`, `transport`, and
 - `wfd-media-pipeline`
 - `wfd-capture-backend`
 - `wfd-latency-log`
+- `wfd-aosp-pmt-pid`
 - `wfd-no-audio`
 - `wfd-audio-device`
 - `wfd-rtsp-port`
@@ -136,6 +138,8 @@ sections also accept `host`, `port`, `discover-timeout`, `transport`, and
 - `wfd-rtp-source-port`
 - `wfd-interface`
 - `wfd-timeout`
+- `wfd-go-intent`
+- `wfd-uibc`
 
 `monitor` preselects the capture output for that mode by its name (as shown by
 `wlr-randr`/`xrandr`, e.g. `HDMI-A-1`), so tray launches skip the monitor
@@ -244,6 +248,14 @@ and protocol selection remain controlled by the tray and cannot be set here.
   - `x11grab`: useful for X11 sessions.
   - `gst-x11`: X11 capture routed through the GStreamer MPEG-TS pipeline (the same one the test pattern uses) instead of ffmpeg. Opt-in and never chosen by `auto`. Use it when a sink connects and streams but shows a black screen on the default ffmpeg path (confirmed on Hisense Vidaa). Requires `gst-launch-1.0`, `ximagesrc` (gst-plugins-good), and `x264enc` (gst-plugins-ugly).
   - `portal` backend requirements: `dbus-next`, `xdg-desktop-portal`, desktop portal backend, and `gst-launch-1.0`.
+- `--wfd-aosp-pmt-pid`
+  - Writes the MPEG-TS PAT/PMT the way Android (AOSP) Miracast sinks expect
+    them (PMT on PID `0x0100`, table version `1`). Use it when the session
+    connects and RTP flows but the sink stays on a black screen - seen on
+    Android TV boxes and projectors (see #84).
+  - Off by default, since the standard layout works on most TVs. Muxes with
+    ffmpeg: `auto` picks the ffmpeg sender, and `gst`/`gst-x11` warn because
+    mpegtsmux cannot set the table version.
 - `--wfd-no-audio`
   - **Video-only mode** - May cause immediate disconnects on Samsung TVs during WFD negotiation.
   - Use primarily for diagnostic/testing purposes.

--- a/src/ui/tray_config.py
+++ b/src/ui/tray_config.py
@@ -52,6 +52,16 @@ def _port(value: str) -> str:
     return str(parsed)
 
 
+def _go_intent(value: str) -> str:
+    try:
+        parsed = int(value.strip())
+    except ValueError as exc:
+        raise ValueError("expected an integer from 0 to 15") from exc
+    if not 0 <= parsed <= 15:
+        raise ValueError("expected an integer from 0 to 15")
+    return str(parsed)
+
+
 def _resolution(value: str) -> str:
     match = re.fullmatch(r"\s*(\d+)[xX](\d+)\s*", value)
     if match is None:
@@ -116,6 +126,7 @@ _MODE_OPTIONS = {
             _choice("auto", "portal", "wf-recorder", "x11grab", "gst-x11")
         ),
         "wfd-latency-log": _Option(_text),
+        "wfd-aosp-pmt-pid": _Option(_boolean, is_flag=True),
         "wfd-no-audio": _Option(_boolean, is_flag=True),
         "wfd-audio-device": _Option(_text),
         "wfd-rtsp-port": _Option(_port),
@@ -123,6 +134,8 @@ _MODE_OPTIONS = {
         "wfd-rtp-source-port": _Option(_port),
         "wfd-interface": _Option(_text),
         "wfd-timeout": _Option(_positive_int),
+        "wfd-go-intent": _Option(_go_intent),
+        "wfd-uibc": _Option(_boolean, is_flag=True),
     },
     "dlna": _DLNA_CAST_OPTIONS,
     "cast": _DLNA_CAST_OPTIONS,

--- a/tests/test_tray_config.py
+++ b/tests/test_tray_config.py
@@ -102,6 +102,36 @@ discover-timeout = 10
             ],
         )
 
+    def test_loads_sink_specific_wfd_options(self):
+        self._write(
+            """
+[wfd]
+wfd-aosp-pmt-pid = true
+wfd-uibc = false
+wfd-go-intent = 0
+"""
+        )
+        warnings = []
+
+        args = tray_config.load_profile(
+            "wfd", config_path=self.config_path, warn=warnings.append
+        )
+
+        self.assertEqual(args, ["--wfd-aosp-pmt-pid", "--wfd-go-intent", "0"])
+        self.assertEqual(warnings, [])
+
+    def test_go_intent_out_of_range_warns(self):
+        self._write("[wfd]\nwfd-go-intent = 16\n")
+        warnings = []
+
+        args = tray_config.load_profile(
+            "wfd", config_path=self.config_path, warn=warnings.append
+        )
+
+        self.assertEqual(args, [])
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("invalid value for 'wfd-go-intent'", warnings[0])
+
     def test_invalid_and_unknown_options_warn_and_fall_back(self):
         self._write(
             """


### PR DESCRIPTION
Fixes #116

`_MODE_OPTIONS["wfd"]` in `src/ui/tray_config.py` only whitelisted 11 of the `--wfd-*` flags, so `wfd-aosp-pmt-pid = true` in `~/.config/fluxcast/config` was dropped with a warning that only reaches the tray log. AOSP-sink users got a black screen from the tray with no visible reason.

Changes:

- `src/ui/tray_config.py`: accept `wfd-aosp-pmt-pid` (flag), `wfd-uibc` (flag) and `wfd-go-intent`. Go intent is validated against the CLI's `0-15` range with a dedicated `_go_intent` validator, since `_positive_int` would reject the default `0`.
- Left out, as the issue suggests: `wfd-p2p-backend`/`wfd-p2p-channel` (may need sudo, no terminal to prompt in), `wfd-dump-ts`/`wfd-ffmpeg-stats` (one-off debugging), `wfd-peer`/`wfd-monitor` (supplied by the tray).
- `tests/test_tray_config.py`: covers the three new keys being forwarded (including `wfd-go-intent = 0` and a false flag being omitted) and an out-of-range go intent warning and falling back.
- `documentation/DOCUMENTATION.md`: `--wfd-aosp-pmt-pid` added to the WFD flag list, given a Flag Details entry under WFD Media (what it changes in the TS, when to use it, ffmpeg-only muxing per `pipeline.py`), and the three keys added to the tray config option list.
- `README.md`: short usage example for Android-based sinks next to the other troubleshooting snippets.

Test run (`PYSTRAY_BACKEND=dummy python -m unittest tests.test_tray_config`): 12 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
