### PR TITLE
Give firewalld queries the Polkit budget; probe state via systemd

### DIFF
--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -666,44 +666,43 @@ def _ufw_check() -> Optional[Check]:
     )
 
 
+# firewalld gates every firewall-cmd call through Polkit, read-only queries
+# included, so on some hosts `--query-port` blocks until the user answers a
+# dialog. Give it the same budget as `--add-port` rather than a 3 s probe.
+_FIREWALL_AUTH_TIMEOUT = 60.0
+
+
+def _firewalld_active() -> bool:
+    # `firewall-cmd --state` goes through Polkit too; asking systemd does not.
+    if not shutil.which("firewall-cmd"):
+        return False
+    try:
+        result = _run(["systemctl", "is-active", "firewalld"], timeout=3.0)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "active"
+
+
 def _firewalld_check() -> Optional[Check]:
     if not shutil.which("firewall-cmd"):
         return None
 
-    try:
-        state = _run(["firewall-cmd", "--state"], timeout=3.0)
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        return Check("firewall (firewalld)", STATUS_WARN, "could not query firewalld state", str(exc))
-
-    # firewalld gates firewall-cmd through polkit, so on a headless/gated host
-    # `--state` and `--query-port` can fail with an authorization error rather
-    # than a real answer. Trust only what firewall-cmd literally prints: a
-    # non-zero exit is not proof the firewall is down, so an auth failure must
-    # never become a definitive OK-or-closed. Report "couldn't verify" instead.
-    state_out = state.stdout.strip()
-    state_all = (state.stdout + state.stderr).strip()
-    if state_out != "running":
-        if "not running" in state_all.lower():
-            return Check(
-                "firewall (firewalld)",
-                STATUS_OK,
-                "firewalld is not running; port not blocked",
-                state_all,
-            )
+    if not _firewalld_active():
         return Check(
             "firewall (firewalld)",
-            STATUS_WARN,
-            "could not verify firewalld state (firewall-cmd did not report running/not running)",
-            state_all,
+            STATUS_OK,
+            "firewalld is not running; port not blocked",
         )
 
     try:
-        query = _run(["firewall-cmd", f"--query-port={WFD_RTSP_PORT}/tcp"], timeout=3.0)
+        query = _run(["firewall-cmd", f"--query-port={WFD_RTSP_PORT}/tcp"], timeout=_FIREWALL_AUTH_TIMEOUT)
     except (OSError, subprocess.TimeoutExpired) as exc:
         return Check("firewall (firewalld)", STATUS_WARN, "could not query firewalld port", str(exc))
 
     # `--query-port` prints `yes`/`no` (exit 0/1) for a real answer; anything
     # else — empty output, an auth error — means we could not check the port.
+    # A non-zero exit is not proof the port is closed, so an auth failure must
+    # never become a definitive OK-or-closed. Report "couldn't verify" instead.
     query_out = query.stdout.strip()
     if query_out == "yes":
         return Check(

--- a/src/diagnostics.py
+++ b/src/diagnostics.py
@@ -666,38 +666,59 @@ def _ufw_check() -> Optional[Check]:
     )
 
 
-# firewalld gates every firewall-cmd call through Polkit, read-only queries
-# included, so on some hosts `--query-port` blocks until the user answers a
-# dialog. Give it the same budget as `--add-port` rather than a 3 s probe.
-_FIREWALL_AUTH_TIMEOUT = 60.0
+def _firewalld_active() -> Optional[bool]:
+    """True/False when systemd reports firewalld active/inactive, None when it
+    could not be asked (no systemctl, no systemd, timeout).
 
-
-def _firewalld_active() -> bool:
-    # `firewall-cmd --state` goes through Polkit too; asking systemd does not.
+    `firewall-cmd --state` goes through Polkit too; asking systemd does not.
+    """
     if not shutil.which("firewall-cmd"):
         return False
     try:
         result = _run(["systemctl", "is-active", "firewalld"], timeout=3.0)
     except (OSError, subprocess.TimeoutExpired):
+        return None
+    state = result.stdout.strip()
+    if result.returncode == 0 and state == "active":
+        return True
+    if state in ("inactive", "failed"):
         return False
-    return result.returncode == 0 and result.stdout.strip() == "active"
+    return None  # e.g. "System has not been booted with systemd" on stderr
 
 
 def _firewalld_check() -> Optional[Check]:
     if not shutil.which("firewall-cmd"):
         return None
 
-    if not _firewalld_active():
+    active = _firewalld_active()
+    if active is None:
+        # Without systemd's answer we do not know; firewalld may well be up and
+        # blocking, so this must not read as a definitive "not running".
+        return Check(
+            "firewall (firewalld)",
+            STATUS_WARN,
+            "could not verify whether firewalld is running (systemctl gave no answer)",
+        )
+    if not active:
         return Check(
             "firewall (firewalld)",
             STATUS_OK,
             "firewalld is not running; port not blocked",
         )
 
+    # This runs at every session start, so keep the short probe budget: a
+    # Polkit-gated query just becomes "could not verify" rather than a dialog
+    # the startup waits on. The session path in wfd/firewall.py, where the
+    # port actually matters, waits for the prompt.
     try:
-        query = _run(["firewall-cmd", f"--query-port={WFD_RTSP_PORT}/tcp"], timeout=_FIREWALL_AUTH_TIMEOUT)
+        query = _run(["firewall-cmd", f"--query-port={WFD_RTSP_PORT}/tcp"], timeout=3.0)
     except (OSError, subprocess.TimeoutExpired) as exc:
-        return Check("firewall (firewalld)", STATUS_WARN, "could not query firewalld port", str(exc))
+        return Check(
+            "firewall (firewalld)",
+            STATUS_WARN,
+            f"could not verify whether firewalld allows port {WFD_RTSP_PORT}/tcp",
+            str(exc),
+        )
 
     # `--query-port` prints `yes`/`no` (exit 0/1) for a real answer; anything
     # else — empty output, an auth error — means we could not check the port.

--- a/src/wfd/__init__.py
+++ b/src/wfd/__init__.py
@@ -163,7 +163,7 @@ from .rtsp.rtsp_server import _ThreadingTCPServer, WFDRTSPServer
 from .proc import _run
 
 
-from .firewall import _firewalld_active, _FIREWALL_AUTH_TIMEOUT, _FIREWALL_QUERY_TIMEOUT, _WFD_FIREWALL_ZONE, _print_firewall_manual_hint, _open_wfd_firewall_port, _close_wfd_firewall_port
+from .firewall import _firewalld_active, _FIREWALL_AUTH_TIMEOUT, _WFD_FIREWALL_ZONE, _print_firewall_manual_hint, _open_wfd_firewall_port, _close_wfd_firewall_port
 
 
 

--- a/src/wfd/firewall.py
+++ b/src/wfd/firewall.py
@@ -1,21 +1,9 @@
-import shutil
 import subprocess
+
+from diagnostics import _FIREWALL_AUTH_TIMEOUT, _firewalld_active
 
 from .proc import _run
 
-
-def _firewalld_active() -> bool:
-    if not shutil.which("firewall-cmd"):
-        return False
-    try:
-        result = _run(["systemctl", "is-active", "firewalld"], timeout=3.0)
-    except (OSError, subprocess.TimeoutExpired):
-        return False
-    return result.returncode == 0 and result.stdout.strip() == "active"
-
-_FIREWALL_AUTH_TIMEOUT = 60.0
-
-_FIREWALL_QUERY_TIMEOUT = 3.0
 
 _WFD_FIREWALL_ZONE = "nm-shared"
 
@@ -38,6 +26,8 @@ def _open_wfd_firewall_port(port: int) -> bool:
     if not _firewalld_active():
         return False
 
+    # Polkit can gate the read-only query as well, so it gets the same budget
+    # as the --add-port it precedes (#114).
     try:
         query = _run(
             [
@@ -45,7 +35,7 @@ def _open_wfd_firewall_port(port: int) -> bool:
                 f"--zone={_WFD_FIREWALL_ZONE}",
                 f"--query-port={port}/tcp",
             ],
-            timeout=_FIREWALL_QUERY_TIMEOUT,
+            timeout=_FIREWALL_AUTH_TIMEOUT,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         _print_firewall_manual_hint(port, f"could not check existing rule: {exc}")

--- a/src/wfd/firewall.py
+++ b/src/wfd/firewall.py
@@ -1,9 +1,14 @@
 import subprocess
 
-from diagnostics import _FIREWALL_AUTH_TIMEOUT, _firewalld_active
+from diagnostics import _firewalld_active
 
 from .proc import _run
 
+
+# firewalld gates every firewall-cmd call through Polkit, read-only queries
+# included, so on some hosts `--query-port` blocks until the user answers a
+# dialog. Give it the same budget as `--add-port` rather than a 3 s probe.
+_FIREWALL_AUTH_TIMEOUT = 60.0
 
 _WFD_FIREWALL_ZONE = "nm-shared"
 
@@ -23,6 +28,7 @@ def _open_wfd_firewall_port(port: int) -> bool:
     exit. Returns True only if WE opened it, so the caller knows to undo it; a
     port the user already had open is left untouched.
     """
+    # None ("couldn't ask systemd") is treated like inactive: nothing to open.
     if not _firewalld_active():
         return False
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -85,14 +85,49 @@ class FirewallCheckTest(unittest.TestCase):
     def test_firewalld_active_is_false_when_unit_inactive(self):
         with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
                 mock.patch("diagnostics._run", return_value=_completed("inactive", returncode=3)):
-            self.assertFalse(diagnostics._firewalld_active())
+            self.assertIs(diagnostics._firewalld_active(), False)
 
-    def test_firewalld_query_waits_for_polkit(self):
-        # The read-only query can block on a Polkit dialog too (#114); it must
-        # get the authorization budget, not the 3 s probe budget.
+    def test_firewalld_doctor_reports_each_systemctl_outcome(self):
+        # Only a definite answer from systemd may become a definite verdict.
+        # "Couldn't ask" (no systemctl, no systemd, hang) must not turn into
+        # "not running; port not blocked": firewalld may be up and blocking.
+        no_systemd = _completed(
+            "", returncode=1,
+            stderr="System has not been booted with systemd as init system (PID 1). Can't operate.",
+        )
+        cases = [
+            ("active", _completed("active"), diagnostics.STATUS_OK, "allows port", True),
+            ("inactive", _completed("inactive", returncode=3), diagnostics.STATUS_OK, "not running", False),
+            ("no systemd", no_systemd, diagnostics.STATUS_WARN, "could not verify", False),
+            ("systemctl missing", FileNotFoundError("systemctl"), diagnostics.STATUS_WARN, "could not verify", False),
+            ("systemctl hangs", subprocess.TimeoutExpired(cmd="systemctl", timeout=3.0), diagnostics.STATUS_WARN, "could not verify", False),
+        ]
+        for name, systemctl_reply, status, message, queries_port in cases:
+            calls = []
+
+            def fake_run(args, timeout=None):
+                calls.append(args)
+                if args[0] == "systemctl":
+                    if isinstance(systemctl_reply, BaseException):
+                        raise systemctl_reply
+                    return systemctl_reply
+                return _completed("yes")
+
+            with self.subTest(name), \
+                    mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
+                    mock.patch("diagnostics._run", side_effect=fake_run):
+                check = diagnostics._firewall_check()
+                self.assertEqual(check.status, status)
+                self.assertIn(message, check.message)
+                self.assertEqual(any(args[0] == "firewall-cmd" for args in calls), queries_port)
+
+    def test_firewalld_doctor_query_keeps_short_budget(self):
+        # run_diagnostics() runs at every session start, so the informational
+        # query must not sit on a Polkit dialog for the 60 s auth budget; that
+        # budget belongs to the session path in wfd/firewall.py only.
         timeouts = []
 
-        def fake_run(args, timeout=3.0):
+        def fake_run(args, timeout=None):
             timeouts.append(timeout)
             return _completed("yes")
 
@@ -101,7 +136,16 @@ class FirewallCheckTest(unittest.TestCase):
                 mock.patch("diagnostics._run", side_effect=fake_run):
             check = diagnostics._firewall_check()
         self.assertEqual(check.status, diagnostics.STATUS_OK)
-        self.assertEqual(timeouts, [diagnostics._FIREWALL_AUTH_TIMEOUT])
+        self.assertEqual(timeouts, [3.0])
+
+    def test_firewalld_doctor_query_timeout_is_could_not_verify(self):
+        with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
+                mock.patch("diagnostics._firewalld_active", return_value=True), \
+                mock.patch("diagnostics._run", side_effect=subprocess.TimeoutExpired(cmd="firewall-cmd", timeout=3.0)):
+            check = diagnostics._firewall_check()
+        self.assertEqual(check.status, diagnostics.STATUS_WARN)
+        self.assertIn("could not verify", check.message)
+        self.assertNotIn("closed", check.message)
 
     def test_firewalld_query_auth_failure_is_not_reported_closed(self):
         # firewalld is running, but the port probe hits an auth error; that is

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -51,47 +51,65 @@ class FirewallCheckTest(unittest.TestCase):
         self.assertEqual(check.status, diagnostics.STATUS_OK)
 
     def test_firewalld_running_without_port_warns(self):
-        def fake_run(args, timeout=3.0):
-            if "--state" in args:
-                return _completed("running")
-            return _completed("no", returncode=1)
-
         with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
-                mock.patch("diagnostics._run", side_effect=fake_run):
+                mock.patch("diagnostics._firewalld_active", return_value=True), \
+                mock.patch("diagnostics._run", return_value=_completed("no", returncode=1)):
             check = diagnostics._firewall_check()
         self.assertEqual(check.name, "firewall (firewalld)")
         self.assertEqual(check.status, diagnostics.STATUS_WARN)
         self.assertIn(f"{diagnostics.WFD_RTSP_PORT}/tcp", check.detail)
 
     def test_firewalld_not_running_is_ok(self):
+        # Answered by systemd alone: firewall-cmd never runs, so no Polkit dialog.
         with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
-                mock.patch("diagnostics._run", return_value=_completed("not running", returncode=252)):
+                mock.patch("diagnostics._firewalld_active", return_value=False), \
+                mock.patch("diagnostics._run") as run:
             check = diagnostics._firewall_check()
         self.assertEqual(check.status, diagnostics.STATUS_OK)
+        run.assert_not_called()
 
-    def test_firewalld_state_auth_failure_does_not_give_all_clear(self):
-        # polkit-gated `--state` fails with an auth error, not "not running";
-        # a non-zero exit must not be read as a clean firewall.
-        err = "Authorization failed.\n    Make sure polkit agent is running or run the application as superuser."
-        with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
-                mock.patch("diagnostics._run", return_value=_completed("", returncode=1, stderr=err)):
-            check = diagnostics._firewall_check()
-        self.assertEqual(check.name, "firewall (firewalld)")
-        self.assertEqual(check.status, diagnostics.STATUS_WARN)
-        self.assertIn("could not verify", check.message)
-
-    def test_firewalld_query_auth_failure_is_not_reported_closed(self):
-        # `--state` says running, but the port probe hits an auth error; that is
-        # "couldn't verify", not a definitive "port closed".
-        err = "Authorization failed."
+    def test_firewalld_active_asks_systemd_not_firewall_cmd(self):
+        # `firewall-cmd --state` is Polkit-gated on some hosts and times out
+        # before the dialog can be answered; `systemctl is-active` is not.
+        calls = []
 
         def fake_run(args, timeout=3.0):
-            if "--state" in args:
-                return _completed("running")
-            return _completed("", returncode=1, stderr=err)
+            calls.append(args)
+            return _completed("active")
 
         with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
                 mock.patch("diagnostics._run", side_effect=fake_run):
+            self.assertTrue(diagnostics._firewalld_active())
+        self.assertEqual(calls, [["systemctl", "is-active", "firewalld"]])
+
+    def test_firewalld_active_is_false_when_unit_inactive(self):
+        with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
+                mock.patch("diagnostics._run", return_value=_completed("inactive", returncode=3)):
+            self.assertFalse(diagnostics._firewalld_active())
+
+    def test_firewalld_query_waits_for_polkit(self):
+        # The read-only query can block on a Polkit dialog too (#114); it must
+        # get the authorization budget, not the 3 s probe budget.
+        timeouts = []
+
+        def fake_run(args, timeout=3.0):
+            timeouts.append(timeout)
+            return _completed("yes")
+
+        with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
+                mock.patch("diagnostics._firewalld_active", return_value=True), \
+                mock.patch("diagnostics._run", side_effect=fake_run):
+            check = diagnostics._firewall_check()
+        self.assertEqual(check.status, diagnostics.STATUS_OK)
+        self.assertEqual(timeouts, [diagnostics._FIREWALL_AUTH_TIMEOUT])
+
+    def test_firewalld_query_auth_failure_is_not_reported_closed(self):
+        # firewalld is running, but the port probe hits an auth error; that is
+        # "couldn't verify", not a definitive "port closed".
+        err = "Authorization failed."
+        with mock.patch("diagnostics.shutil.which", side_effect=lambda b: "/usr/bin/firewall-cmd" if b == "firewall-cmd" else None), \
+                mock.patch("diagnostics._firewalld_active", return_value=True), \
+                mock.patch("diagnostics._run", return_value=_completed("", returncode=1, stderr=err)):
             check = diagnostics._firewall_check()
         self.assertEqual(check.status, diagnostics.STATUS_WARN)
         self.assertIn("could not verify", check.message)
@@ -121,11 +139,10 @@ class FirewallCheckTest(unittest.TestCase):
         def fake_run(args, timeout=3.0):
             if args[0] == "ufw":
                 return _completed("Status: inactive")
-            if "--state" in args:
-                return _completed("running")
             return _completed("no", returncode=1)
 
         with mock.patch("diagnostics.shutil.which", side_effect=lambda b: f"/usr/bin/{b}" if b in ("ufw", "firewall-cmd") else None), \
+                mock.patch("diagnostics._firewalld_active", return_value=True), \
                 mock.patch("diagnostics._run", side_effect=fake_run):
             check = diagnostics._firewall_check()
         self.assertEqual(check.name, "firewall (firewalld)")

--- a/tests/test_wfd.py
+++ b/tests/test_wfd.py
@@ -125,6 +125,8 @@ class FirewallPortTest(unittest.TestCase):
         self.assertTrue(opened)
         self.assertIn(f"--query-port={port}/tcp", calls[0][0])
         self.assertIn(f"--add-port={port}/tcp", calls[1][0])
+        # Both calls can block on the same Polkit dialog (#114).
+        self.assertEqual(calls[0][1], calls[1][1])
 
     def test_query_error_fails_closed_without_add(self):
         port = wfd.WFD_RTSP_PORT

--- a/tests/test_wfd.py
+++ b/tests/test_wfd.py
@@ -127,6 +127,19 @@ class FirewallPortTest(unittest.TestCase):
         self.assertIn(f"--add-port={port}/tcp", calls[1][0])
         # Both calls can block on the same Polkit dialog (#114).
         self.assertEqual(calls[0][1], calls[1][1])
+        self.assertEqual(calls[0][1], wfd._FIREWALL_AUTH_TIMEOUT)
+
+    def test_unknown_firewalld_state_skips_without_querying(self):
+        # None ("couldn't ask systemd") is treated like inactive here: no
+        # firewall-cmd call, no Polkit dialog, nothing to undo on exit.
+        with (
+            patch_all("_firewalld_active", return_value=None),
+            patch_all("_run") as run,
+        ):
+            opened = wfd._open_wfd_firewall_port(wfd.WFD_RTSP_PORT)
+
+        self.assertFalse(opened)
+        run.assert_not_called()
 
     def test_query_error_fails_closed_without_add(self):
         port = wfd.WFD_RTSP_PORT


### PR DESCRIPTION
Fixes #114

On Polkit-gated firewalld hosts the read-only `--query-port` run before `--add-port` died at 3 s, before the dialog could be answered, so the port stayed closed and the session sat in "waiting for TV RTSP/WFD session". The doctor's `--state` had the same 3 s limit and raised a Polkit dialog on every startup.

- `src/wfd/firewall.py`: the session-path `--query-port` now uses `_FIREWALL_AUTH_TIMEOUT` (60 s), the same budget as the `--add-port` it precedes. `_FIREWALL_QUERY_TIMEOUT` is removed (also from the `wfd/__init__.py` re-export; nothing else referenced it).
- `src/diagnostics.py`: `_firewalld_check()` replaces `firewall-cmd --state` with `_firewalld_active()` (`systemctl is-active firewalld`), which never touches Polkit, so `--doctor` no longer raises a dialog on every startup. `_firewalld_active()` is tri-state: `True`/`False` when systemd answered, `None` when it could not be asked (no `systemctl`, no systemd, timeout), which the doctor reports as "could not verify" rather than "not running". The doctor's informational `--query-port` keeps the 3 s probe budget so session startup never waits on a Polkit dialog; a timeout is reported as "could not verify".

`_firewalld_active()` moved from `wfd/firewall.py` into `diagnostics.py` rather than being imported the other way: `wfd/__init__.py` already does `from diagnostics import ...`, so `diagnostics` importing `wfd.firewall` is a circular import. `wfd/firewall.py` imports it from `diagnostics` and treats `None` like inactive (nothing to open), so `wfd._firewalld_active` still resolves and the existing `patch_all("_firewalld_active", ...)` tests keep working. `_FIREWALL_AUTH_TIMEOUT` stays in `wfd/firewall.py`.

Tests: `test_diagnostics` covers the doctor verdict for each `systemctl` outcome (active / inactive / no systemd / missing / hang) with the real `_firewalld_active`, that a not-running or unverifiable firewalld never invokes `firewall-cmd`, that the doctor's query passes the 3 s budget, and that a query timeout is "could not verify". `test_wfd` asserts the session query and add calls share `_FIREWALL_AUTH_TIMEOUT` and that `None` skips `firewall-cmd`. `python3 -m unittest tests.test_diagnostics tests.test_wfd`: 65 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
